### PR TITLE
fix: await add/remove capability

### DIFF
--- a/drivers/energylink/device.js
+++ b/drivers/energylink/device.js
@@ -91,7 +91,7 @@ class HomeWizardEnergylink extends Homey.Device {
 		var homewizard_id = this.getSetting('homewizard_id');
 
 		var me = this;
-		homewizard.getDeviceData(homewizard_id, 'energylinks', function(callback){
+		homewizard.getDeviceData(homewizard_id, 'energylinks', async function(callback){
 
 			if (Object.keys(callback).length > 0) {
 
@@ -144,8 +144,8 @@ class HomeWizardEnergylink extends Homey.Device {
 						var solar_daytotal_prod = solar_daytotal_prod + energy_daytotal_prod;
 
 						if (me.hasCapability('meter_power.s1other')) {
-							me.removeCapability('meter_power.s1other');
-	            me.removeCapability('measure_power.s1other');
+							await me.removeCapability('meter_power.s1other');
+							await me.removeCapability('measure_power.s1other');
 						}
 					}
 
@@ -156,8 +156,8 @@ class HomeWizardEnergylink extends Homey.Device {
 						var solar_current_prod = solar_current_prod + energy_current_prod;
 						var solar_daytotal_prod = solar_daytotal_prod + energy_daytotal_prod;
 						if (me.hasCapability('meter_power.s2other')) {
-							me.removeCapability('meter_power.s2other');
-	            me.removeCapability('measure_power.s2other');
+							await me.removeCapability('meter_power.s2other');
+							await me.removeCapability('measure_power.s2other');
 						}
 					}
 
@@ -165,8 +165,8 @@ class HomeWizardEnergylink extends Homey.Device {
 						me.setCapabilityValue("measure_power.s1", solar_current_prod );
 						me.setCapabilityValue("meter_power.s1", solar_daytotal_prod );
 						if (me.hasCapability('meter_power.s1other')) {
-							me.removeCapability('meter_power.s1other');
-							me.removeCapability('measure_power.s1other');
+							await me.removeCapability('meter_power.s1other');
+							await me.removeCapability('measure_power.s1other');
 						}
 					}
 
@@ -179,8 +179,8 @@ class HomeWizardEnergylink extends Homey.Device {
 						me.setCapabilityValue("measure_water", water_current_cons);
 
 						if (me.hasCapability('meter_power.s1other')) {
-							me.removeCapability('meter_power.s1other');
-	            me.removeCapability('measure_power.s1other');
+							await me.removeCapability('meter_power.s1other');
+							await me.removeCapability('measure_power.s1other');
 						}
 					}
 
@@ -193,8 +193,8 @@ class HomeWizardEnergylink extends Homey.Device {
 						me.setCapabilityValue("meter_water", water_daytotal_cons);
 						me.setCapabilityValue("measure_water", water_current_cons);
 						if (me.hasCapability('meter_power.s2other')) {
-							me.removeCapability('meter_power.s2other');
-	            me.removeCapability('measure_power.s2other');
+							await me.removeCapability('meter_power.s2other');
+							await me.removeCapability('measure_power.s2other');
 						}
 					}
 
@@ -307,7 +307,7 @@ class HomeWizardEnergylink extends Homey.Device {
 		var homewizard_id = this.getSetting('homewizard_id');
 
 		var me = this;
-		homewizard.getDeviceData(homewizard_id, 'energylink_el', function (callback) {
+		homewizard.getDeviceData(homewizard_id, 'energylink_el', async function (callback) {
 
 			if (Object.keys(callback).length > 0) {
 				try {
@@ -323,7 +323,7 @@ class HomeWizardEnergylink extends Homey.Device {
 					// Save export data
 
 					if (!me.hasCapability('meter_power')) {
-						me.addCapability('meter_power');
+						await me.addCapability('meter_power');
 					}
 
 					me.setCapabilityValue("meter_gas.reading", metered_gas);

--- a/drivers/kakusensors/device.js
+++ b/drivers/kakusensors/device.js
@@ -63,7 +63,7 @@ class HomeWizardKakusensors extends Homey.Device {
 			if(devices[index].settings.homewizard_id !== undefined ) {
 				var homewizard_id = devices[index].settings.homewizard_id;
 				var kakusensor_id = devices[index].settings.kakusensor_id;
-				homewizard.getDeviceData(homewizard_id, 'kakusensors', function(result) {
+				homewizard.getDeviceData(homewizard_id, 'kakusensors', async function(result) {
 					 if (Object.keys(result).length > 0) {
 					 try {
 							for (var index2 in result) {
@@ -77,7 +77,7 @@ class HomeWizardKakusensors extends Homey.Device {
 										// MOTION SENSOR 	alarm_motion
 										//me.removeCapability('alarm_smoke');
 										if (!devices[index].hasCapability('alarm_motion')) {
-        							devices[index].addCapability('alarm_motion');
+        							await devices[index].addCapability('alarm_motion');
       							}
 
 										if (devices[index].getCapabilityValue('alarm_motion') != sensor_status) {
@@ -89,7 +89,7 @@ class HomeWizardKakusensors extends Homey.Device {
 									if (result[index2].type == "smoke868" ) {
 										// MOTION SENSOR 	alarm_smoke
 										if (!devices[index].hasCapability('alarm_smoke')) {
-											devices[index].addCapability('alarm_smoke');
+											await devices[index].addCapability('alarm_smoke');
 										}
 										if (devices[index].getCapabilityValue('alarm_smoke') != sensor_status) {
 											if (debug) {console.log("New status - "+ sensor_status);}
@@ -100,7 +100,7 @@ class HomeWizardKakusensors extends Homey.Device {
 											if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
 													if (debug) {console.log(result[index2].lowBattery);}
 													if (!devices[index].hasCapability('alarm_battery')) {
-														devices[index].addCapability('alarm_battery');
+														await devices[index].addCapability('alarm_battery');
 													}
 
 													var lowBattery_temp = result[index2].lowBattery;
@@ -122,7 +122,7 @@ class HomeWizardKakusensors extends Homey.Device {
 									if (result[index2].type == "leakage" ) {
 										// MOTION SENSOR 	alarm_water
 										if (!devices[index].hasCapability('alarm_water')) {
-											devices[index].addCapability('alarm_water');
+											await devices[index].addCapability('alarm_water');
 										}
 										if (devices[index].getCapabilityValue('alarm_water') != sensor_status) {
 											if (debug) {console.log("New status - "+ sensor_status);}
@@ -133,7 +133,7 @@ class HomeWizardKakusensors extends Homey.Device {
 											if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
 													if (debug) {console.log(result[index2].lowBattery);}
 													if (!devices[index].hasCapability('alarm_battery')) {
-														devices[index].addCapability('alarm_battery');
+														await devices[index].addCapability('alarm_battery');
 													}
 
 													var lowBattery_temp = result[index2].lowBattery;
@@ -155,10 +155,10 @@ class HomeWizardKakusensors extends Homey.Device {
 									if (result[index2].type == "smoke" ) {
 										// MOTION SENSOR 	alarm_smoke
 										if (!devices[index].hasCapability('alarm_smoke')) {
-											devices[index].addCapability('alarm_smoke');
+											await devices[index].addCapability('alarm_smoke');
 										}
 										if (devices[index].hasCapability('alarm_battery')) {
-											devices[index].removeCapability('alarm_battery');
+											await devices[index].removeCapability('alarm_battery');
 										}
 
 										if (devices[index].getCapabilityValue('alarm_smoke') != sensor_status) {
@@ -171,7 +171,7 @@ class HomeWizardKakusensors extends Homey.Device {
 									if (result[index2].type == "contact" ) {
 										// MOTION SENSOR 	alarm_smoke
 										if (!devices[index].hasCapability('alarm_contact')) {
-											devices[index].addCapability('alarm_contact');
+											await devices[index].addCapability('alarm_contact');
 										}
 										if (devices[index].getCapabilityValue('alarm_contact') != sensor_status) {
 											if (debug) {console.log("New status - "+ sensor_status);}
@@ -182,7 +182,7 @@ class HomeWizardKakusensors extends Homey.Device {
 									if (result[index2].type == "doorbell" ) {
 										// MOTION SENSOR 	alarm_smoke
 										if (!devices[index].hasCapability('alarm_generic')) {
-											devices[index].addCapability('alarm_generic');
+											await devices[index].addCapability('alarm_generic');
 										}
 										if (devices[index].getCapabilityValue('alarm_generic') != sensor_status) {
 											if (debug) {console.log("New status - "+ sensor_status);}

--- a/drivers/thermometer/device.js
+++ b/drivers/thermometer/device.js
@@ -59,7 +59,7 @@ class HomeWizardThermometer extends Homey.Device {
 			if(devices[index].settings.homewizard_id !== undefined ) {
 				var homewizard_id = devices[index].settings.homewizard_id;
 				var thermometer_id = devices[index].settings.thermometer_id;
-				homewizard.getDeviceData(homewizard_id, 'thermometers', function(result) {
+				homewizard.getDeviceData(homewizard_id, 'thermometers', async function(result) {
 					if (Object.keys(result).length > 0) {
 						try {
 							for (var index2 in result) {
@@ -84,7 +84,7 @@ class HomeWizardThermometer extends Homey.Device {
 										if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
 												//console.log(result[index2].lowBattery);
 												if (!devices[index].hasCapability('alarm_battery')) {
-													devices[index].addCapability('alarm_battery');
+													await devices[index].addCapability('alarm_battery');
 												}
 												var lowBattery_temp = result[index2].lowBattery;
 												if (lowBattery_temp == 'yes') {
@@ -99,7 +99,7 @@ class HomeWizardThermometer extends Homey.Device {
 										}
 										else {
 											if (devices[index].hasCapability('alarm_battery')) {
-												devices[index].removeCapability('alarm_battery');
+												await devices[index].removeCapability('alarm_battery');
 											}
 										}
 									} catch (e) {


### PR DESCRIPTION
Hi! I noticed you are using `addCapability` and `removeCapability` without awaiting, these are async methods that should be awaited in principle. I was tracing a bug that might be related to the fact that this app calls `addCapability` and `setCapabilityValue` directly after each other without awaiting the first. Could you consider merging this PR?

Please note: I could not test this.