### PR TITLE
Match names to official branding

### DIFF
--- a/app.json
+++ b/app.json
@@ -1448,7 +1448,7 @@
     {
       "id": "energy",
       "name": {
-        "en": "Energy (P1 Dongle)"
+        "en": "P1 Meter"
       },
       "images": {
         "large": "drivers/energy/assets/images/large.png",
@@ -1630,7 +1630,7 @@
     {
       "id": "SDM630",
       "name": {
-        "en": "kwh meter (3 phase)"
+        "en": "kWh Meter (3 phase)"
       },
       "images": {
         "large": "drivers/SDM630/assets/images/large.png",
@@ -1752,7 +1752,7 @@
     {
       "id": "SDM230",
       "name": {
-        "en": "kwh meter (1 phase)"
+        "en": "kWh Meter (1 phase)"
       },
       "images": {
         "large": "drivers/SDM230/assets/images/large.png",

--- a/readme.txt
+++ b/readme.txt
@@ -11,11 +11,11 @@ After connecting your HomeWizard Base Station, you can add the following devices
 - Smoke sensor
 
 These products can be connected without the HomeWizard Base Station:
-- Energy (P1 Dongle)
-- kwh meter 1 and 3 phase type (SDM230 and SDM630)
+- Energy (P1 Meter)
+- kWh Meter 1 and 3 phase type (SDM230 and SDM630)
 - Energy Socket
 - Watermeter (Lauch mid august 2022)
 
 NOTE! - ENABLE "LOCAL API" FOR YOUR ENERGY SOCKET, WATERMETER FIRST IN THE OFFICIAL HOMEWIZARD ENERGY APP
-- kwh meter 1 and 3 phase type (SDM230 and SDM630)
+- kWh Meter 1 and 3 phase type (SDM230 and SDM630)
 - Energy Socket


### PR DESCRIPTION
Official naming is, whereby 'HomeWizard' and 'Wi-Fi' is optional:
- (HomeWizard) (Wi-Fi) P1 Meter
- (HomeWizard) (Wi-Fi) kWh Meter
- (HomeWizard) (Wi-Fi) Energy Socket
- (HomeWizard) (Wi-Fi) Watermeter