### PR TITLE
Use product_name for default name, and append serial number if more than one device is discovered

### DIFF
--- a/drivers/SDM230/driver.js
+++ b/drivers/SDM230/driver.js
@@ -9,19 +9,28 @@ module.exports = class HomeWizardEnergyDriver230 extends Homey.Driver {
 
     const discoveryStrategy = this.getDiscoveryStrategy();
     await new Promise((resolve) => setTimeout(resolve, 1000));
+    
     const discoveryResults = discoveryStrategy.getDiscoveryResults();
+    const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
     await new Promise((resolve) => setTimeout(resolve, 1000));
+    
     const devices = [];
     await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
       try {
-        const url = `http://${discoveryResult.address}:${discoveryResult.port}${discoveryResult.txt.path}/data`;
+        const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
         const res = await fetch(url);
         if( !res.ok )
           throw new Error(res.statusText);
 
         const data = await res.json();
+
+        let name = data.product_name
+        if (numberOfDiscoveryResults > 1) {
+          name = `${data.product_name} (${data.serial})`
+        }
+
         devices.push({
-          name: data.meter_model,
+          name: name,
           data: {
             id: discoveryResult.id,
           },

--- a/drivers/SDM630/driver.js
+++ b/drivers/SDM630/driver.js
@@ -9,20 +9,28 @@ module.exports = class HomeWizardEnergyDriver630 extends Homey.Driver {
 
     const discoveryStrategy = this.getDiscoveryStrategy();
     await new Promise((resolve) => setTimeout(resolve, 1000));
+    
     const discoveryResults = discoveryStrategy.getDiscoveryResults();
+    const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     const devices = [];
     await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
       try {
-        const url = `http://${discoveryResult.address}:${discoveryResult.port}${discoveryResult.txt.path}/data`;
+        const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
         const res = await fetch(url);
         if( !res.ok )
           throw new Error(res.statusText);
 
         const data = await res.json();
+
+        let name = data.product_name
+        if (numberOfDiscoveryResults > 1) {
+          name = `${data.product_name} (${data.serial})`
+        }
+
         devices.push({
-          name: data.meter_model,
+          name: name,
           data: {
             id: discoveryResult.id,
           },

--- a/drivers/plugin_battery/driver.js
+++ b/drivers/plugin_battery/driver.js
@@ -16,6 +16,8 @@ module.exports = class HomeWizardEnergyDriverV2 extends Homey.Driver {
         
             const discoveryStrategy = this.getDiscoveryStrategy();
             const discoveryResults = discoveryStrategy.getDiscoveryResults();
+            const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
+            
             const devices = [];
             await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
               try {
@@ -49,7 +51,7 @@ module.exports = class HomeWizardEnergyDriverV2 extends Homey.Driver {
         
                 console.log("Bearer token: ", result.token);
                 
-                const res = await fetch(`https://${discoveryResult.address}/api/measurement`, {
+                const res = await fetch(`https://${discoveryResult.address}/api`, {
                   headers: {
                     'Authorization': `Bearer ${bearer_token}`
                   },
@@ -60,9 +62,14 @@ module.exports = class HomeWizardEnergyDriverV2 extends Homey.Driver {
                   throw new Error(res.statusText);
         
                 const data = await res.json();
+                
+                let name = data.product_name
+                if (numberOfDiscoveryResults > 1) {
+                  name = `${data.product_name} (${data.serial})`
+                }
         
                 devices.push({
-                  name: data.meter_model,
+                  name: name,
                   data: {
                     id: discoveryResult.id,
                   },

--- a/drivers/watermeter/driver.js
+++ b/drivers/watermeter/driver.js
@@ -9,20 +9,28 @@ module.exports = class HomeWizardEnergyWatermeterDriver extends Homey.Driver {
 
     const discoveryStrategy = this.getDiscoveryStrategy();
     await new Promise((resolve) => setTimeout(resolve, 1000));
+
     const discoveryResults = discoveryStrategy.getDiscoveryResults();
+    const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     const devices = [];
     await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
       try {
-        const url = `http://${discoveryResult.address}:${discoveryResult.port}${discoveryResult.txt.path}/data`;
+        const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
         const res = await fetch(url);
         if( !res.ok )
           throw new Error(res.statusText);
 
         const data = await res.json();
+
+        let name = data.product_name
+        if (numberOfDiscoveryResults > 1) {
+          name = `${data.product_name} (${data.serial})`
+        }
+
         devices.push({
-          name: data.meter_model,
+          name: name,
           data: {
             id: discoveryResult.id,
           },


### PR DESCRIPTION
- Instead of using the incorrect `api/v1/data:model_name`, use the `api:product_name` for all Energy devices except P1 Meter (I actually like the smart meter name here!)
- For devices that users _generally_ only have one off (all but Energy Socket), append a serial ID for the same reason as #107 