### PR TITLE
Set correct device class for Energy Meters

### DIFF
--- a/app.json
+++ b/app.json
@@ -1942,7 +1942,7 @@
         "large": "drivers/SDM630/assets/images/large.png",
         "small": "drivers/SDM630/assets/images/small.png"
       },
-      "class": "socket",
+      "class": "sensor",
       "discovery": "SDM630",
       "platforms": [
         "local"
@@ -2073,7 +2073,7 @@
         "large": "drivers/SDM230/assets/images/large.png",
         "small": "drivers/SDM230/assets/images/small.png"
       },
-      "class": "socket",
+      "class": "sensor",
       "discovery": "SDM230",
       "platforms": [
         "local"


### PR DESCRIPTION
SSIA

the SDM230/KWH1 and SDM630/KWH3 where a 'schakeldoos'/socket. Which is not true.

![Schermafbeelding 2025-03-09 om 13 43 00](https://github.com/user-attachments/assets/0630783e-194e-4598-b0d1-3f4b21df94c6)
