### PR TITLE
Implement eslint and lint codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,24 +1,29 @@
 {
-  "extends": "eslint:recommended",
-  "env": {
-    "node":  true,
-    "es6": true,
-    "mocha": true,
-    "browser": true
-  },
-  "linebreak-style": 0,
+  "extends": "athom",
   "rules": {
-    "no-mixed-spaces-and-tabs": 0, // disable rule
-    "callback-return": "warn",
-    "handle-callback-err": "error",
-    "no-new-require": "error",
-    "no-empty-function": "error",
-    "global-require": "error",
-    "no-return-await": "error",
-    "no-catch-shadow": "error",
-    "no-await-in-loop": "error",
-    "array-callback-return" : "error",
-    "no-invalid-this" : "error"
+    "brace-style": "off",
+    "camelcase": "off",
+    "consistent-return": "off",
+    "eqeqeq": "off",
+    "func-names": "off",
+    "global-require": "off",
+    "guard-for-in": "off",
+    "import/extensions": "off",
+    "max-len": 0,
+    "no-async-promise-executor": "off",
+    "no-cond-assign": "off",
+    "no-console": "off",
+    "no-const-assign": "off",
+    "no-const-assignt": "off",
+    "no-constant-condition": "off",
+    "no-mixed-spaces-and-tabs": "off",
+    "no-new": "off",
+    "no-restricted-syntax": "off",
+    "no-tabs": "off",
+    "no-undef": "off",
+    "no-unused-vars": "off",
+    "node/no-unsupported-features/node-builtins": "off",
+    "radix": "off",
+    "valid-typeof": "off"
   }
-
 }

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,8 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: 20.9.0
           cache: 'npm'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -13,22 +13,34 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  homey-validate:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 20.9.0
-          cache: "npm"
+          cache: 'npm'
 
       - name: Install Homey CLI
-        run: npm install --no-optional homey
-      - run: npm install --include=optional sharp
+        run: npm ci --no-optional homey
+      - run: npm ci --include=optional sharp
 
       - name: Validate Homey App
         run: npx homey app validate --level=publish
+
+  lint-eslint:
+    name: eslint
+    runs-on: ubuntu-latest
+
+    steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-node@v4
+          with:
+              node-version: 20.9.0
+              cache: 'npm'
+
+        - run: npm ci
+        - run: npm run lint

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,5 +1,5 @@
 ---
-name: Validate Homey App
+name: CI
 
 on:
   pull_request:
@@ -15,6 +15,7 @@ permissions:
 jobs:
   homey-validate:
     runs-on: ubuntu-latest
+    name: Validate Homey App
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -43,4 +43,4 @@ jobs:
               cache: 'npm'
 
         - run: npm ci
-        - run: npm run lint
+        - run: npm run lint-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: linter
+        name: Linter
+        pass_filenames: False
+        language: system
+        entry: npm run lint
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: no-commit-to-branch
+        name: Check if commit is not in branch 'master'
+        args:
+          - --branch=main # For future us
+          - --branch=master
+
+      - id: end-of-file-fixer
+      - id: check-json
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: trailing-whitespace
+      - id: mixed-line-ending

--- a/app.js
+++ b/app.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict';
 
 const Homey = require('homey');
 
 const Testing = false;
 
 class HomeWizardApp extends Homey.App {
-	onInit() {
-		console.log("HomeWizard app ready!");
-		if (process.env.DEBUG === '1' && Testing) {
-			try{ 
-				require('inspector').waitForDebugger();
-			}
-			catch(error){
-				require('inspector').open(9225, '0.0.0.0', true);
-			}
-		}
+  onInit() {
+    console.log('HomeWizard app ready!');
+    if (process.env.DEBUG === '1' && Testing) {
+      try {
+        require('inspector').waitForDebugger();
+      }
+      catch (error) {
+        require('inspector').open(9225, '0.0.0.0', true);
+      }
+    }
 
-	}
+  }
 }
 
 module.exports = HomeWizardApp;

--- a/drivers/SDM230/device.js
+++ b/drivers/SDM230/device.js
@@ -16,7 +16,7 @@ module.exports = class HomeWizardEnergyDevice230 extends Homey.Device {
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
   }
@@ -42,28 +42,28 @@ module.exports = class HomeWizardEnergyDevice230 extends Homey.Device {
   }
 
   onPoll() {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
-      
+
       let res = await fetch(`${this.url}/data`);
-      
-      if( !res || !res.ok ) {
-        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users 
+
+      if (!res || !res.ok) {
+        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users
         // try again
         res = await fetch(`${this.url}/data`);
-        if( !res || !res.ok )
-          throw new Error(res ? res.statusText : 'Unknown error during fetch');
+        if (!res || !res.ok)
+        { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
       }
 
       const data = await res.json();
 
-    // OLD CODE / REPLACED BY SOCKET METHOD
-     // if (((data.active_power_w < 0) || (data.active_power_l1_w < 0)) && (this.getClass() == 'sensor')) {
-     //   if (this.getClass() != 'solarpanel') {
-     //     await this.setClass('solarpanel').catch(this.error);
-     //   }
-     // }
+      // OLD CODE / REPLACED BY SOCKET METHOD
+      // if (((data.active_power_w < 0) || (data.active_power_l1_w < 0)) && (this.getClass() == 'sensor')) {
+      //   if (this.getClass() != 'solarpanel') {
+      //     await this.setClass('solarpanel').catch(this.error);
+      //   }
+      // }
 
       // Save export data check if capabilities are present first
       if (!this.hasCapability('measure_power')) {
@@ -76,7 +76,7 @@ module.exports = class HomeWizardEnergyDevice230 extends Homey.Device {
 
       if (!this.hasCapability('meter_power.consumed.t1')) {
         await this.addCapability('meter_power.consumed.t1').catch(this.error);
-        //await this.addCapability('meter_power.consumed.t2').catch(this.error);
+        // await this.addCapability('meter_power.consumed.t2').catch(this.error);
       }
 
       if (!this.hasCapability('measure_power.l1')) {
@@ -88,7 +88,7 @@ module.exports = class HomeWizardEnergyDevice230 extends Homey.Device {
       }
 
       if (this.getCapabilityValue('rssi') != data.wifi_strength)
-        await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error);
+      { await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error); }
 
       // Update values 3phase kwh
       // KWH 1 fase
@@ -101,85 +101,82 @@ module.exports = class HomeWizardEnergyDevice230 extends Homey.Device {
 
       // First we need to check if the kwh active_power_w is negative (solar)
 
-//      if ((data.active_power_w < 0) || (data.active_power_l1_w < 0) || (this.getClass() != 'socket')) {
-//        if (this.getClass() != 'solarpanel') {
-//          await this.setClass('solarpanel').catch(this.error);
-//        }
-//      }
-
+      //      if ((data.active_power_w < 0) || (data.active_power_l1_w < 0) || (this.getClass() != 'socket')) {
+      //        if (this.getClass() != 'solarpanel') {
+      //          await this.setClass('solarpanel').catch(this.error);
+      //        }
+      //      }
 
       // There are old paired SDM230 devices that still have the old sensor and show negative values that needs to be inverted
       if (this.getClass() == 'solarpanel') {
-              await this.setCapabilityValue('measure_power', data.active_power_w * -1).catch(this.error);
+        await this.setCapabilityValue('measure_power', data.active_power_w * -1).catch(this.error);
       } else {
         await this.setCapabilityValue('measure_power', data.active_power_w).catch(this.error);
       }
 
-
-      //await this.setCapabilityValue('measure_power.active_power_w', data.active_power_w).catch(this.error);
+      // await this.setCapabilityValue('measure_power.active_power_w', data.active_power_w).catch(this.error);
       await this.setCapabilityValue('meter_power.consumed.t1', data.total_power_import_t1_kwh).catch(this.error);
 
-      //There are old paired SDM230 devices that still have the old sensor and show negative values that needs to be inverted
+      // There are old paired SDM230 devices that still have the old sensor and show negative values that needs to be inverted
       if (this.getClass() == 'solarpanel') {
-          await this.setCapabilityValue('measure_power.l1', data.active_power_l1_w *-1).catch(this.error);
+        await this.setCapabilityValue('measure_power.l1', data.active_power_l1_w * -1).catch(this.error);
       } else {
-          await this.setCapabilityValue('measure_power.l1', data.active_power_l1_w).catch(this.error);
+        await this.setCapabilityValue('measure_power.l1', data.active_power_l1_w).catch(this.error);
       }
-      //await this.setCapabilityValue('meter_power.consumed.t2', data.total_power_import_t2_kwh).catch(this.error);
+      // await this.setCapabilityValue('meter_power.consumed.t2', data.total_power_import_t2_kwh).catch(this.error);
 
       // Check to see if there is solar panel production exported if received value is more than 1 it returned back to the power grid
       if (data.total_power_export_t1_kwh > 1) {
-								if (!this.hasCapability('meter_power.produced.t1')) {
-                  // add production meters
-									await this.addCapability('meter_power.produced.t1').catch(this.error);
-								}
-                // update values for solar production
-								await this.setCapabilityValue('meter_power.produced.t1', data.total_power_export_t1_kwh).catch(this.error);
-			}
+        if (!this.hasCapability('meter_power.produced.t1')) {
+          // add production meters
+          await this.addCapability('meter_power.produced.t1').catch(this.error);
+        }
+        // update values for solar production
+        await this.setCapabilityValue('meter_power.produced.t1', data.total_power_export_t1_kwh).catch(this.error);
+      }
       else if (data.total_power_export_t1_kwh < 1) {
-              await this.removeCapability('meter_power.produced.t1').catch(this.error);
+        await this.removeCapability('meter_power.produced.t1').catch(this.error);
       }
 
       // aggregated meter for Power by the hour support
       if (!this.hasCapability('meter_power')) {
-          await this.addCapability('meter_power').catch(this.error);
+        await this.addCapability('meter_power').catch(this.error);
       }
       // update calculated value which is sum of import deducted by the sum of the export this overall kwh number is used for Power by the hour app
-      await this.setCapabilityValue('meter_power', (data.total_power_import_t1_kwh-data.total_power_export_t1_kwh)).catch(this.error);
+      await this.setCapabilityValue('meter_power', (data.total_power_import_t1_kwh - data.total_power_export_t1_kwh)).catch(this.error);
 
-      //active_voltage_l1_v
+      // active_voltage_l1_v
       if (data.active_voltage_v !== undefined) {
         if (!this.hasCapability('measure_voltage')) {
           await this.addCapability('measure_voltage').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_voltage') != data.active_voltage_v)
-        await this.setCapabilityValue("measure_voltage", data.active_voltage_v).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_voltage') != data.active_voltage_v)
+        { await this.setCapabilityValue('measure_voltage', data.active_voltage_v).catch(this.error); }
       }
       else if ((data.active_voltage_v == undefined) && (this.hasCapability('measure_voltage'))) {
         await this.removeCapability('measure_voltage').catch(this.error);
       }
 
-      //active_current_a  Amp's 
+      // active_current_a  Amp's
       if (data.active_current_a !== undefined) {
         if (!this.hasCapability('measure_current')) {
           await this.addCapability('measure_current').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_current') != data.active_current_a)
-          await this.setCapabilityValue("measure_current", data.active_current_a).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_current') != data.active_current_a)
+        { await this.setCapabilityValue('measure_current', data.active_current_a).catch(this.error); }
       }
       else if ((data.active_current_a == undefined) && (this.hasCapability('measure_current'))) {
-          await this.removeCapability('measure_current').catch(this.error);
+        await this.removeCapability('measure_current').catch(this.error);
       }
-
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         this.error(err);
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
-}
+};

--- a/drivers/SDM230/driver.js
+++ b/drivers/SDM230/driver.js
@@ -9,38 +9,38 @@ module.exports = class HomeWizardEnergyDriver230 extends Homey.Driver {
 
     const discoveryStrategy = this.getDiscoveryStrategy();
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    
+
     const discoveryResults = discoveryStrategy.getDiscoveryResults();
     const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    
+
     const devices = [];
-    await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
+    await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
       try {
         const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
         const res = await fetch(url);
-        if( !res.ok )
-          throw new Error(res.statusText);
+        if (!res.ok)
+        { throw new Error(res.statusText); }
 
         const data = await res.json();
 
-        let name = data.product_name
+        let name = data.product_name;
         if (numberOfDiscoveryResults > 1) {
-          name = `${data.product_name} (${data.serial})`
+          name = `${data.product_name} (${data.serial})`;
         }
 
         devices.push({
-          name: name,
+          name,
           data: {
             id: discoveryResult.id,
           },
-        })
-      } catch( err ) {
+        });
+      } catch (err) {
         this.error(discoveryResult.id, err);
       }
     }));
     return devices;
 
-}
+  }
 
-}
+};

--- a/drivers/SDM630/device.js
+++ b/drivers/SDM630/device.js
@@ -3,7 +3,6 @@
 const Homey = require('homey');
 const fetch = require('node-fetch');
 
-
 const POLL_INTERVAL = 1000 * 10; // 10 seconds
 
 module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
@@ -17,7 +16,7 @@ module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
   }
@@ -43,17 +42,17 @@ module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
   }
 
   onPoll() {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
       let res = await fetch(`${this.url}/data`);
-      
-      if( !res || !res.ok ) {
-        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users 
+
+      if (!res || !res.ok) {
+        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users
         // try again
         res = await fetch(`${this.url}/data`);
-        if( !res || !res.ok )
-          throw new Error(res ? res.statusText : 'Unknown error during fetch');
+        if (!res || !res.ok)
+        { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
       }
       const data = await res.json();
 
@@ -65,7 +64,7 @@ module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
       if (!this.hasCapability('measure_power.active_power_w')) {
         await this.addCapability('measure_power.active_power_w').catch(this.error);
       }
-      
+
       if (!this.hasCapability('meter_power.consumed.t1')) {
         await this.addCapability('meter_power.consumed.t1').catch(this.error);
       //  await this.addCapability('meter_power.consumed.t2').catch(this.error);
@@ -76,7 +75,7 @@ module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
       }
 
       if (this.getCapabilityValue('rssi') != data.wifi_strength)
-        await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error);
+      { await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error); }
 
       // Update values 3phase kwh
       // KWH 1 fase
@@ -90,34 +89,34 @@ module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
       await this.setCapabilityValue('measure_power', data.active_power_w).catch(this.error);
       await this.setCapabilityValue('measure_power.active_power_w', data.active_power_w).catch(this.error);
       await this.setCapabilityValue('meter_power.consumed.t1', data.total_power_import_t1_kwh).catch(this.error);
-      //await this.setCapabilityValue('meter_power.consumed.t2', data.total_power_import_t2_kwh).catch(this.error);
+      // await this.setCapabilityValue('meter_power.consumed.t2', data.total_power_import_t2_kwh).catch(this.error);
 
       // Check to see if there is solar panel production exported if received value is more than 1 it returned back to the power grid
       if (data.total_power_export_t1_kwh > 1) {
-								if (!this.hasCapability('meter_power.produced.t1')) {
-                  // add production meters
-									await this.addCapability('meter_power.produced.t1').catch(this.error);
-								}
-                // update values for solar production
-								await this.setCapabilityValue('meter_power.produced.t1', data.total_power_export_t1_kwh).catch(this.error);
-			}
+        if (!this.hasCapability('meter_power.produced.t1')) {
+          // add production meters
+          await this.addCapability('meter_power.produced.t1').catch(this.error);
+        }
+        // update values for solar production
+        await this.setCapabilityValue('meter_power.produced.t1', data.total_power_export_t1_kwh).catch(this.error);
+      }
       else if (data.total_power_export_t1_kwh < 1) {
-              await this.removeCapability('meter_power.produced.t1').catch(this.error);
+        await this.removeCapability('meter_power.produced.t1').catch(this.error);
       }
 
       // aggregated meter for Power by the hour support
       if (!this.hasCapability('meter_power')) {
-          await this.addCapability('meter_power').catch(this.error);
+        await this.addCapability('meter_power').catch(this.error);
       }
       // update calculated value which is sum of import deducted by the sum of the export this overall kwh number is used for Power by the hour app
-      this.setCapabilityValue('meter_power', (data.total_power_import_t1_kwh-data.total_power_export_t1_kwh)).catch(this.error);
+      this.setCapabilityValue('meter_power', (data.total_power_import_t1_kwh - data.total_power_export_t1_kwh)).catch(this.error);
 
       // Phase 3 support when meter has values active_power_l2_w will be valid else ignore ie the power grid is a Phase1 household connection
-     if (data.active_power_l2_w !== null) {
-         if (!this.hasCapability('measure_power.l2')) {
-           await this.addCapability('measure_power.l1').catch(this.error);
-           await this.addCapability('measure_power.l2').catch(this.error);
-           await this.addCapability('measure_power.l3').catch(this.error);
+      if (data.active_power_l2_w !== null) {
+        if (!this.hasCapability('measure_power.l2')) {
+          await this.addCapability('measure_power.l1').catch(this.error);
+          await this.addCapability('measure_power.l2').catch(this.error);
+          await this.addCapability('measure_power.l3').catch(this.error);
         }
         this.setCapabilityValue('measure_power.l1', data.active_power_l1_w).catch(this.error);
         this.setCapabilityValue('measure_power.l2', data.active_power_l2_w).catch(this.error);
@@ -132,86 +131,86 @@ module.exports = class HomeWizardEnergyDevice630 extends Homey.Device {
         }
       }
 
-      //active_voltage_l1_v
+      // active_voltage_l1_v
       if (data.active_voltage_l1_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l1')) {
           await this.addCapability('measure_voltage.l1').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_voltage.l1') != data.active_voltage_l1_v)
-        await this.setCapabilityValue("measure_voltage.l1", data.active_voltage_l1_v).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_voltage.l1') != data.active_voltage_l1_v)
+        { await this.setCapabilityValue('measure_voltage.l1', data.active_voltage_l1_v).catch(this.error); }
       }
       else if ((data.active_voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
         await this.removeCapability('measure_voltage.l1').catch(this.error);
       }
 
-      //active_voltage_l2_v
+      // active_voltage_l2_v
       if (data.active_voltage_l2_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l2')) {
           await this.addCapability('measure_voltage.l2').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_voltage.l2') != data.active_voltage_l2_v)
-      await this.setCapabilityValue("measure_voltage.l2", data.active_voltage_l2_v).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_voltage.l2') != data.active_voltage_l2_v)
+        { await this.setCapabilityValue('measure_voltage.l2', data.active_voltage_l2_v).catch(this.error); }
       }
       else if ((data.active_voltage_l2_v == undefined) && (this.hasCapability('measure_voltage.l2'))) {
         await this.removeCapability('measure_voltage.l2').catch(this.error);
       }
 
-      //active_voltage_l3_v
+      // active_voltage_l3_v
       if (data.active_voltage_l3_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l3')) {
           await this.addCapability('measure_voltage.l3').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_voltage.l3') != data.active_voltage_l3_v)
-      await this.setCapabilityValue("measure_voltage.l3", data.active_voltage_l3_v).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_voltage.l3') != data.active_voltage_l3_v)
+        { await this.setCapabilityValue('measure_voltage.l3', data.active_voltage_l3_v).catch(this.error); }
       }
       else if ((data.active_voltage_l3_v == undefined) && (this.hasCapability('measure_voltage.l3'))) {
         await this.removeCapability('measure_voltage.l3').catch(this.error);
       }
 
-      //active_current_a  Amp's L1
+      // active_current_a  Amp's L1
       if (data.active_current_l1_a !== undefined) {
         if (!this.hasCapability('measure_current.l1')) {
           await this.addCapability('measure_current.l1').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
-          await this.setCapabilityValue("measure_current.l1", data.active_current_l1_a).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
+        { await this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error); }
       }
       else if ((data.active_current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
-          await this.removeCapability('measure_current.l1').catch(this.error);
+        await this.removeCapability('measure_current.l1').catch(this.error);
       }
 
-      //active_current_a  Amp's L2
+      // active_current_a  Amp's L2
       if (data.active_current_l2_a !== undefined) {
         if (!this.hasCapability('measure_current.l2')) {
           await this.addCapability('measure_current.l2').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_current.l2') != data.active_current_l2_a)
-          await this.setCapabilityValue("measure_current.l2", data.active_current_l2_a).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_current.l2') != data.active_current_l2_a)
+        { await this.setCapabilityValue('measure_current.l2', data.active_current_l2_a).catch(this.error); }
       }
       else if ((data.active_current_l2_a == undefined) && (this.hasCapability('measure_current.l2'))) {
-          await this.removeCapability('measure_current.l2').catch(this.error);
+        await this.removeCapability('measure_current.l2').catch(this.error);
       }
 
-      //active_current_a  Amp's L3
+      // active_current_a  Amp's L3
       if (data.active_current_l3_a !== undefined) {
         if (!this.hasCapability('measure_current.l3')) {
           await this.addCapability('measure_current.l3').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_current.l3') != data.active_current_l3_a)
-          await this.setCapabilityValue("measure_current.l3", data.active_current_l3_a).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_current.l3') != data.active_current_l3_a)
+        { await this.setCapabilityValue('measure_current.l3', data.active_current_l3_a).catch(this.error); }
       }
       else if ((data.active_current_l3_a == undefined) && (this.hasCapability('measure_current.l3'))) {
-          await this.removeCapability('measure_current.l3').catch(this.error);
+        await this.removeCapability('measure_current.l3').catch(this.error);
       }
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         this.error(err);
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
-}
+};

--- a/drivers/SDM630/driver.js
+++ b/drivers/SDM630/driver.js
@@ -9,38 +9,38 @@ module.exports = class HomeWizardEnergyDriver630 extends Homey.Driver {
 
     const discoveryStrategy = this.getDiscoveryStrategy();
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    
+
     const discoveryResults = discoveryStrategy.getDiscoveryResults();
     const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     const devices = [];
-    await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
+    await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
       try {
         const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
         const res = await fetch(url);
-        if( !res.ok )
-          throw new Error(res.statusText);
+        if (!res.ok)
+        { throw new Error(res.statusText); }
 
         const data = await res.json();
 
-        let name = data.product_name
+        let name = data.product_name;
         if (numberOfDiscoveryResults > 1) {
-          name = `${data.product_name} (${data.serial})`
+          name = `${data.product_name} (${data.serial})`;
         }
 
         devices.push({
-          name: name,
+          name,
           data: {
             id: discoveryResult.id,
           },
-        })
-      } catch( err ) {
+        });
+      } catch (err) {
         this.error(discoveryResult.id, err);
       }
     }));
     return devices;
 
-}
+  }
 
-}
+};

--- a/drivers/energy/device.js
+++ b/drivers/energy/device.js
@@ -16,20 +16,20 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
 
   }
 
-  flowTriggerTariff( device, tokens ) {
-    this._flowTriggerTariff.trigger( device, tokens ).catch( this.error )
+  flowTriggerTariff(device, tokens) {
+    this._flowTriggerTariff.trigger(device, tokens).catch(this.error);
   }
 
-  flowTriggerImport( device, tokens ) {
-    this._flowTriggerImport.trigger( device, tokens ).catch( this.error )
+  flowTriggerImport(device, tokens) {
+    this._flowTriggerImport.trigger(device, tokens).catch(this.error);
   }
 
-  flowTriggerExport( device, tokens ) {
-    this._flowTriggerExport.trigger( device, tokens ).catch( this.error )
+  flowTriggerExport(device, tokens) {
+    this._flowTriggerExport.trigger(device, tokens).catch(this.error);
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
   }
@@ -55,17 +55,17 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
   }
 
   onPoll() {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
       let res = await fetch(`${this.url}/data`);
-      
-      if( !res || !res.ok ) {
-        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users 
+
+      if (!res || !res.ok) {
+        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users
         // try again
         res = await fetch(`${this.url}/data`);
-        if( !res || !res.ok )
-          throw new Error(res ? res.statusText : 'Unknown error during fetch');
+        if (!res || !res.ok)
+        { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
       }
 
       const data = await res.json();
@@ -76,10 +76,9 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
         promises.push(this.addCapability('measure_power').catch(this.error));
       }
 
-//      if (!this.hasCapability('measure_current.l1') && (data.active_current_l1_a !== undefined)) {
-//        promises.push(this.addCapability('measure_current.l1').catch(this.error));
-//      }
-
+      //      if (!this.hasCapability('measure_current.l1') && (data.active_current_l1_a !== undefined)) {
+      //        promises.push(this.addCapability('measure_current.l1').catch(this.error));
+      //      }
 
       if (this.hasCapability('measure_power.active_power_w')) {
         promises.push(this.removeCapability('measure_power.active_power_w').catch(this.error));
@@ -104,24 +103,24 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
 
       // Update values
       if (this.getCapabilityValue('measure_power') != data.active_power_w)
-      promises.push(this.setCapabilityValue('measure_power', data.active_power_w).catch(this.error));
-      //if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
-      //promises.push(this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error));
+      { promises.push(this.setCapabilityValue('measure_power', data.active_power_w).catch(this.error)); }
+      // if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
+      // promises.push(this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error));
       if (this.getCapabilityValue('meter_power.consumed.t1') != data.total_power_import_t1_kwh)
-      promises.push(this.setCapabilityValue('meter_power.consumed.t1', data.total_power_import_t1_kwh).catch(this.error));
+      { promises.push(this.setCapabilityValue('meter_power.consumed.t1', data.total_power_import_t1_kwh).catch(this.error)); }
       if (this.getCapabilityValue('meter_power.consumed.t2') != data.total_power_import_t2_kwh)
-      promises.push(this.setCapabilityValue('meter_power.consumed.t2', data.total_power_import_t2_kwh).catch(this.error));
+      { promises.push(this.setCapabilityValue('meter_power.consumed.t2', data.total_power_import_t2_kwh).catch(this.error)); }
       if (this.getCapabilityValue('rssi') != data.wifi_strength)
-      promises.push(this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error));
+      { promises.push(this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error)); }
       if (this.getCapabilityValue('tariff') != data.active_tariff)
-      promises.push(this.setCapabilityValue('tariff', data.active_tariff).catch(this.error));
+      { promises.push(this.setCapabilityValue('tariff', data.active_tariff).catch(this.error)); }
       if (this.getCapabilityValue('meter_power.consumed') != data.total_power_import_kwh)
-      promises.push(this.setCapabilityValue('meter_power.consumed', data.total_power_import_kwh).catch(this.error));
+      { promises.push(this.setCapabilityValue('meter_power.consumed', data.total_power_import_kwh).catch(this.error)); }
 
-      //Trigger tariff
-      if (data.active_tariff != this.getStoreValue("last_active_tariff")) {
+      // Trigger tariff
+      if (data.active_tariff != this.getStoreValue('last_active_tariff')) {
         this.flowTriggerTariff(this, { tariff_changed: data.active_tariff });
-        this.setStoreValue("last_active_tariff",data.active_tariff).catch(this.error);
+        this.setStoreValue('last_active_tariff', data.active_tariff).catch(this.error);
       }
 
       if (data.active_current_l1_a !== undefined) {
@@ -129,42 +128,41 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
           promises.push(this.addCapability('measure_current.l1').catch(this.error));
         }
         if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
-        promises.push(this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error));
+        { promises.push(this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error)); }
       }
       else if (data.active_current_l1_a == null) {
         // delete measure_current.l1 -> some meters dont have this property
         promises.push(this.removeCapability('measure_current.l1').catch(this.error));
       }
 
-
       // Not all users have a gas meter in their system (if NULL ignore creation or even delete from view)
-      
+
       if (data.total_gas_m3 !== undefined) {
       								if (!this.hasCapability('meter_gas')) {
       									promises.push(this.addCapability('meter_gas').catch(this.error));
       								}
-                      if (this.getCapabilityValue('meter_gas') != data.total_gas_m3)
-                      promises.push(this.setCapabilityValue('meter_gas', data.total_gas_m3).catch(this.error));
+        if (this.getCapabilityValue('meter_gas') != data.total_gas_m3)
+        { promises.push(this.setCapabilityValue('meter_gas', data.total_gas_m3).catch(this.error)); }
       							}
       							else if (data.total_gas_m3 == null) {
-                      // delete gas meter
+        // delete gas meter
       								promises.push(this.removeCapability('meter_gas').catch(this.error));
       }
 
       // Check to see if there is solar panel production exported if received value is more than 1 it returned back to the power grid
       if ((data.total_power_export_kwh > 1) || (data.total_power_export_t2_kwh > 1)) {
-								if ((!this.hasCapability('meter_power.produced.t1')) || (!this.hasCapability('meter_power.returned'))) {
-                  // add production meters
-									promises.push(this.addCapability('meter_power.produced.t1').catch(this.error));
-									promises.push(this.addCapability('meter_power.produced.t2').catch(this.error));
-                  promises.push(this.addCapability('meter_power.returned').catch(this.error));
-								}
-                // update values for solar production
-                if (this.getCapabilityValue('meter_power.produced.t1') != data.total_power_export_t1_kwh)
-                promises.push(this.setCapabilityValue("meter_power.produced.t1", data.total_power_export_t1_kwh).catch(this.error));
-                if (this.getCapabilityValue('meter_power.produced.t2') != data.total_power_export_t2_kwh)
-                promises.push(this.setCapabilityValue("meter_power.produced.t2", data.total_power_export_t2_kwh).catch(this.error));
-			}
+        if ((!this.hasCapability('meter_power.produced.t1')) || (!this.hasCapability('meter_power.returned'))) {
+          // add production meters
+          promises.push(this.addCapability('meter_power.produced.t1').catch(this.error));
+          promises.push(this.addCapability('meter_power.produced.t2').catch(this.error));
+          promises.push(this.addCapability('meter_power.returned').catch(this.error));
+        }
+        // update values for solar production
+        if (this.getCapabilityValue('meter_power.produced.t1') != data.total_power_export_t1_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.produced.t1', data.total_power_export_t1_kwh).catch(this.error)); }
+        if (this.getCapabilityValue('meter_power.produced.t2') != data.total_power_export_t2_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.produced.t2', data.total_power_export_t2_kwh).catch(this.error)); }
+      }
       else if ((data.total_power_export_kwh < 1) || (data.total_power_export_t2_kwh < 1)) {
         promises.push(this.removeCapability('meter_power.produced.t1').catch(this.error));
         promises.push(this.removeCapability('meter_power.produced.t2').catch(this.error));
@@ -177,200 +175,200 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
       // update calculated value which is sum of import deducted by the sum of the export this overall kwh number is used for Power by the hour app
       // Pre P1 firmware 4.x
       if (data.total_power_import_kwh === undefined) {
-        if (this.getCapabilityValue('meter_power') != ((data.total_power_import_t1_kwh+data.total_power_import_t2_kwh)-(data.total_power_export_t1_kwh+data.total_power_export_t2_kwh)))
-        promises.push(this.setCapabilityValue('meter_power', ((data.total_power_import_t1_kwh+data.total_power_import_t2_kwh)-(data.total_power_export_t1_kwh+data.total_power_export_t2_kwh))).catch(this.error));
+        if (this.getCapabilityValue('meter_power') != ((data.total_power_import_t1_kwh + data.total_power_import_t2_kwh) - (data.total_power_export_t1_kwh + data.total_power_export_t2_kwh)))
+        { promises.push(this.setCapabilityValue('meter_power', ((data.total_power_import_t1_kwh + data.total_power_import_t2_kwh) - (data.total_power_export_t1_kwh + data.total_power_export_t2_kwh))).catch(this.error)); }
       }
       // P1 Firmwmare 4.x and later
       else if (data.total_power_import_kwh !== undefined) {
-        if (this.getCapabilityValue('meter_power') != (data.total_power_import_kwh-data.total_power_export_kwh))
-        promises.push(this.setCapabilityValue('meter_power', (data.total_power_import_kwh-data.total_power_export_kwh)).catch(this.error));
+        if (this.getCapabilityValue('meter_power') != (data.total_power_import_kwh - data.total_power_export_kwh))
+        { promises.push(this.setCapabilityValue('meter_power', (data.total_power_import_kwh - data.total_power_export_kwh)).catch(this.error)); }
         if (this.getCapabilityValue('meter_power.returned') != data.total_power_export_kwh)
-        promises.push(this.setCapabilityValue('meter_power.returned', data.total_power_export_kwh).catch(this.error));
+        { promises.push(this.setCapabilityValue('meter_power.returned', data.total_power_export_kwh).catch(this.error)); }
       }
 
-      //Trigger import
-      if (data.total_power_import_kwh != this.getStoreValue("last_total_import_kwh")) {
+      // Trigger import
+      if (data.total_power_import_kwh != this.getStoreValue('last_total_import_kwh')) {
         this.flowTriggerImport(this, { import_changed: data.total_power_import_kwh });
-        this.setStoreValue("last_total_import_kwh",data.total_power_import_kwh).catch(this.error);
-     }
+        this.setStoreValue('last_total_import_kwh', data.total_power_import_kwh).catch(this.error);
+      }
 
-      //Trigger export
-      if (data.total_power_export_kwh != this.getStoreValue("last_total_export_kwh")) {
+      // Trigger export
+      if (data.total_power_export_kwh != this.getStoreValue('last_total_export_kwh')) {
         this.flowTriggerExport(this, { export_changed: data.total_power_export_kwh });
-        this.setStoreValue("last_total_export_kwh",data.total_power_export_kwh).catch(this.error);
-     }
+        this.setStoreValue('last_total_export_kwh', data.total_power_export_kwh).catch(this.error);
+      }
 
-      //Belgium 
+      // Belgium
       if (data.montly_power_peak_w !== undefined) {
         if (!this.hasCapability('measure_power.montly_power_peak')) {
           promises.push(this.addCapability('measure_power.montly_power_peak').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.montly_power_peak') != data.montly_power_peak_w)
-      promises.push(this.setCapabilityValue("measure_power.montly_power_peak", data.montly_power_peak_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.montly_power_peak') != data.montly_power_peak_w)
+        { promises.push(this.setCapabilityValue('measure_power.montly_power_peak', data.montly_power_peak_w).catch(this.error)); }
       }
       else if ((data.montly_power_peak_w == undefined) && (this.hasCapability('measure_power.montly_power_peak'))) {
         promises.push(this.removeCapability('measure_power.montly_power_peak').catch(this.error));
       }
 
-      //active_voltage_l1_v Some P1 meters do have voltage data
+      // active_voltage_l1_v Some P1 meters do have voltage data
       if (data.active_voltage_l1_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l1')) {
           promises.push(this.addCapability('measure_voltage.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l1') != data.active_voltage_l1_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l1", data.active_voltage_l1_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l1') != data.active_voltage_l1_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l1', data.active_voltage_l1_v).catch(this.error)); }
       }
       else if ((data.active_voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
         promises.push(this.removeCapability('measure_voltage.l1').catch(this.error));
       }
 
-      //active_current_l1_a Some P1 meters do have amp data
+      // active_current_l1_a Some P1 meters do have amp data
       if (data.active_current_l1_a !== undefined) {
         if (!this.hasCapability('measure_current.l1')) {
           promises.push(this.addCapability('measure_current.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
-      promises.push(this.setCapabilityValue("measure_current.l1", data.active_current_l1_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
+        { promises.push(this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error)); }
       }
       else if ((data.active_current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
         promises.push(this.removeCapability('measure_current.l1').catch(this.error));
       }
 
-      //Power failure count - long_power_fail_count
+      // Power failure count - long_power_fail_count
       if (data.long_power_fail_count !== undefined) {
         if (!this.hasCapability('long_power_fail_count')) {
           promises.push(this.addCapability('long_power_fail_count').catch(this.error));
-      }
-      if (this.getCapabilityValue('long_power_fail_count') != data.long_power_fail_count)
-      promises.push(this.setCapabilityValue("long_power_fail_count", data.long_power_fail_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('long_power_fail_count') != data.long_power_fail_count)
+        { promises.push(this.setCapabilityValue('long_power_fail_count', data.long_power_fail_count).catch(this.error)); }
       }
       else if ((data.long_power_fail_count == undefined) && (this.hasCapability('long_power_fail_count'))) {
         promises.push(this.removeCapability('long_power_fail_count').catch(this.error));
       }
 
-      //voltage_sag_l1_count - Net L1 dip 
+      // voltage_sag_l1_count - Net L1 dip
       if (data.voltage_sag_l1_count !== undefined) {
         if (!this.hasCapability('voltage_sag_l1')) {
           promises.push(this.addCapability('voltage_sag_l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_sag_l1') != data.voltage_sag_l1_count)
-      promises.push(this.setCapabilityValue("voltage_sag_l1", data.voltage_sag_l1_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_sag_l1') != data.voltage_sag_l1_count)
+        { promises.push(this.setCapabilityValue('voltage_sag_l1', data.voltage_sag_l1_count).catch(this.error)); }
       }
       else if ((data.voltage_sag_l1_count == undefined) && (this.hasCapability('voltage_sag_l1'))) {
         promises.push(this.removeCapability('voltage_sag_l1').catch(this.error));
       }
 
-      //voltage_sag_l2_count - Net L2 dip 
+      // voltage_sag_l2_count - Net L2 dip
       if (data.voltage_sag_l2_count !== undefined) {
         if (!this.hasCapability('voltage_sag_l2')) {
           promises.push(this.addCapability('voltage_sag_l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_sag_l2') != data.voltage_sag_l2_count)
-      promises.push(this.setCapabilityValue("voltage_sag_l2", data.voltage_sag_l2_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_sag_l2') != data.voltage_sag_l2_count)
+        { promises.push(this.setCapabilityValue('voltage_sag_l2', data.voltage_sag_l2_count).catch(this.error)); }
       }
       else if ((data.voltage_sag_l2_count == undefined) && (this.hasCapability('voltage_sag_l2'))) {
         promises.push(this.removeCapability('voltage_sag_l2').catch(this.error));
       }
 
-      //voltage_sag_l3_count - Net L3 dip 
+      // voltage_sag_l3_count - Net L3 dip
       if (data.voltage_sag_l3_count !== undefined) {
         if (!this.hasCapability('voltage_sag_l3')) {
           promises.push(this.addCapability('voltage_sag_l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_sag_l3') != data.voltage_sag_l3_count)
-      promises.push(this.setCapabilityValue("voltage_sag_l3", data.voltage_sag_l3_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_sag_l3') != data.voltage_sag_l3_count)
+        { promises.push(this.setCapabilityValue('voltage_sag_l3', data.voltage_sag_l3_count).catch(this.error)); }
       }
       else if ((data.voltage_sag_l3_count == undefined) && (this.hasCapability('voltage_sag_l3'))) {
         promises.push(this.removeCapability('voltage_sag_l3').catch(this.error));
       }
-      
-       //voltage_swell_l1_count - Net L1 peak 
-       if (data.voltage_swell_l1_count !== undefined) {
+
+      // voltage_swell_l1_count - Net L1 peak
+      if (data.voltage_swell_l1_count !== undefined) {
         if (!this.hasCapability('voltage_swell_l1')) {
           promises.push(this.addCapability('voltage_swell_l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_swell_l1') != data.voltage_swell_l1_count)
-      promises.push(this.setCapabilityValue("voltage_swell_l1", data.voltage_swell_l1_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_swell_l1') != data.voltage_swell_l1_count)
+        { promises.push(this.setCapabilityValue('voltage_swell_l1', data.voltage_swell_l1_count).catch(this.error)); }
       }
       else if ((data.voltage_swell_l1_count == undefined) && (this.hasCapability('voltage_swell_l1'))) {
         promises.push(this.removeCapability('voltage_swell_l1').catch(this.error));
       }
 
-      //voltage_swell_l2_count - Net L2 peak 
+      // voltage_swell_l2_count - Net L2 peak
       if (data.voltage_swell_l2_count !== undefined) {
         if (!this.hasCapability('voltage_swell_l2')) {
           promises.push(this.addCapability('voltage_swell_l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_swell_l2') != data.voltage_swell_l2_count)
-      promises.push(this.setCapabilityValue("voltage_swell_l2", data.voltage_swell_l2_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_swell_l2') != data.voltage_swell_l2_count)
+        { promises.push(this.setCapabilityValue('voltage_swell_l2', data.voltage_swell_l2_count).catch(this.error)); }
       }
       else if ((data.voltage_swell_l2_count == undefined) && (this.hasCapability('voltage_swell_l2'))) {
         promises.push(this.removeCapability('voltage_swell_l2').catch(this.error));
       }
 
-      //voltage_swell_l3_count - Net L3 peak 
+      // voltage_swell_l3_count - Net L3 peak
       if (data.voltage_swell_l3_count !== undefined) {
         if (!this.hasCapability('voltage_swell_l3')) {
           promises.push(this.addCapability('voltage_swell_l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_swell_l3') != data.voltage_swell_l3_count)
-      promises.push(this.setCapabilityValue("voltage_swell_l3", data.voltage_swell_l3_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_swell_l3') != data.voltage_swell_l3_count)
+        { promises.push(this.setCapabilityValue('voltage_swell_l3', data.voltage_swell_l3_count).catch(this.error)); }
       }
       else if ((data.voltage_swell_l3_count == undefined) && (this.hasCapability('voltage_swell_l3'))) {
         promises.push(this.removeCapability('voltage_swell_l3').catch(this.error));
       }
 
-      //Rewrite of L1/L2/L3 Voltage/Amp
+      // Rewrite of L1/L2/L3 Voltage/Amp
       if (data.active_power_l1_w !== undefined) {
         if (!this.hasCapability('measure_power.l1')) {
           promises.push(this.addCapability('measure_power.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.l1') != data.active_power_l1_w)
-          promises.push(this.setCapabilityValue("measure_power.l1", data.active_power_l1_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.l1') != data.active_power_l1_w)
+        { promises.push(this.setCapabilityValue('measure_power.l1', data.active_power_l1_w).catch(this.error)); }
       }
       else if ((data.active_power_l1_w == undefined) && (this.hasCapability('measure_power.l1'))) {
         promises.push(this.removeCapability('measure_power.l1').catch(this.error));
       }
-	  
+
       if (data.active_power_l2_w !== undefined) {
         if (!this.hasCapability('measure_power.l2')) {
           promises.push(this.addCapability('measure_power.l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.l2') != data.active_power_l2_w)
-      promises.push(this.setCapabilityValue("measure_power.l2", data.active_power_l2_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.l2') != data.active_power_l2_w)
+        { promises.push(this.setCapabilityValue('measure_power.l2', data.active_power_l2_w).catch(this.error)); }
       }
       else if ((data.active_power_l2_w == undefined) && (this.hasCapability('measure_power.l2'))) {
         promises.push(this.removeCapability('measure_power.l2').catch(this.error));
       }
-	  
+
       if (data.active_power_l3_w !== undefined) {
         if (!this.hasCapability('measure_power.l3')) {
           promises.push(this.addCapability('measure_power.l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.l3') != data.active_power_l3_w)
-      promises.push(this.setCapabilityValue("measure_power.l3", data.active_power_l3_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.l3') != data.active_power_l3_w)
+        { promises.push(this.setCapabilityValue('measure_power.l3', data.active_power_l3_w).catch(this.error)); }
       }
       else if ((data.active_power_l3_w == undefined) && (this.hasCapability('measure_power.l3'))) {
         promises.push(this.removeCapability('measure_power.l3').catch(this.error));
       }
-	  
+
       if (data.active_voltage_l1_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l1')) {
           promises.push(this.addCapability('measure_voltage.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l1') != data.active_voltage_l1_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l1", data.active_voltage_l1_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l1') != data.active_voltage_l1_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l1', data.active_voltage_l1_v).catch(this.error)); }
       }
       else if ((data.active_voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
         promises.push(this.removeCapability('measure_voltage.l1').catch(this.error));
       }
-	  
+
       if (data.active_voltage_l2_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l2')) {
           promises.push(this.addCapability('measure_voltage.l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l2') != data.active_voltage_l2_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l2", data.active_voltage_l2_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l2') != data.active_voltage_l2_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l2', data.active_voltage_l2_v).catch(this.error)); }
       }
       else if ((data.active_voltage_l2_v == undefined) && (this.hasCapability('measure_voltage.l2'))) {
         promises.push(this.removeCapability('measure_voltage.l2').catch(this.error));
@@ -379,54 +377,54 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
       if (data.active_voltage_l3_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l3')) {
           promises.push(this.addCapability('measure_voltage.l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l3') != data.active_voltage_l3_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l3", data.active_voltage_l3_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l3') != data.active_voltage_l3_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l3', data.active_voltage_l3_v).catch(this.error)); }
       }
       else if ((data.active_voltage_l3_v == undefined) && (this.hasCapability('measure_voltage.l3'))) {
         promises.push(this.removeCapability('measure_voltage.l3').catch(this.error));
       }
-	  
+
       if (data.active_current_l1_a !== undefined) {
         if (!this.hasCapability('measure_current.l1')) {
           promises.push(this.addCapability('measure_current.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
-      promises.push(this.setCapabilityValue("measure_current.l1", data.active_current_l1_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l1') != data.active_current_l1_a)
+        { promises.push(this.setCapabilityValue('measure_current.l1', data.active_current_l1_a).catch(this.error)); }
       }
       else if ((data.active_current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
         promises.push(this.removeCapability('measure_current.l1').catch(this.error));
       }
-	  
+
       if (data.active_current_l2_a !== undefined) {
         if (!this.hasCapability('measure_current.l2')) {
           promises.push(this.addCapability('measure_current.l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l2') != data.active_current_l2_a)
-      promises.push(this.setCapabilityValue("measure_current.l2", data.active_current_l2_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l2') != data.active_current_l2_a)
+        { promises.push(this.setCapabilityValue('measure_current.l2', data.active_current_l2_a).catch(this.error)); }
       }
       else if ((data.active_current_l2_a == undefined) && (this.hasCapability('measure_current.l2'))) {
         promises.push(this.removeCapability('measure_current.l2').catch(this.error));
       }
-	  
+
       if (data.active_current_l3_a !== undefined) {
         if (!this.hasCapability('measure_current.l3')) {
           promises.push(this.addCapability('measure_current.l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l3') != data.active_current_l3_a)
-      promises.push(this.setCapabilityValue("measure_current.l3", data.active_current_l3_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l3') != data.active_current_l3_a)
+        { promises.push(this.setCapabilityValue('measure_current.l3', data.active_current_l3_a).catch(this.error)); }
       }
       else if ((data.active_current_l3_a == undefined) && (this.hasCapability('measure_current.l3'))) {
         promises.push(this.removeCapability('measure_current.l3').catch(this.error));
       }
-	  
-      //T3 meter request import and export
+
+      // T3 meter request import and export
       if (data.total_power_import_t3_kwh !== undefined) {
         if (!this.hasCapability('meter_power.consumed.t3')) {
           promises.push(this.addCapability('meter_power.consumed.t3').catch(this.error));
-      }
-      if (this.getCapabilityValue('meter_power.consumed.t3') != data.total_power_import_t3_kwh)
-      promises.push(this.setCapabilityValue("meter_power.consumed.t3", data.total_power_import_t3_kwh).catch(this.error));
+        }
+        if (this.getCapabilityValue('meter_power.consumed.t3') != data.total_power_import_t3_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.consumed.t3', data.total_power_import_t3_kwh).catch(this.error)); }
       }
       else if ((data.total_power_import_t3_kwh == undefined) && (this.hasCapability('meter_power.consumed.t3'))) {
         promises.push(this.removeCapability('meter_power.consumed.t3').catch(this.error));
@@ -435,9 +433,9 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
       if (data.total_power_export_t3_kwh !== undefined) {
         if (!this.hasCapability('meter_power.produced.t3')) {
           promises.push(this.addCapability('meter_power.produced.t3').catch(this.error));
-      }
-      if (this.getCapabilityValue('meter_power.produced.t3') != data.total_power_export_t3_kwh)
-      promises.push(this.setCapabilityValue("meter_power.produced.t3", data.total_power_export_t3_kwh).catch(this.error));
+        }
+        if (this.getCapabilityValue('meter_power.produced.t3') != data.total_power_export_t3_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.produced.t3', data.total_power_export_t3_kwh).catch(this.error)); }
       }
       else if ((data.total_power_export_t3_kwh == undefined) && (this.hasCapability('meter_power.produced.t3'))) {
         promises.push(this.removeCapability('meter_power.produced.t3').catch(this.error));
@@ -450,49 +448,44 @@ module.exports = class HomeWizardEnergyDevice extends Homey.Device {
       let latestWaterData = null;
       if (externalData && externalData.length > 0) {
 
-          // Find the water data with the latest timestamp
-          latestWaterData = externalData.reduce((prev, current) => {
-              if (current.type === 'water_meter') {
-                  if (!prev || current.timestamp > prev.timestamp) {
-                      return current;
-                  }
-              }
-              return prev;
-          }, null);
+        // Find the water data with the latest timestamp
+        latestWaterData = externalData.reduce((prev, current) => {
+          if (current.type === 'water_meter') {
+            if (!prev || current.timestamp > prev.timestamp) {
+              return current;
+            }
+          }
+          return prev;
+        }, null);
       }
 
       if (latestWaterData) {
-          // Access water data
-          const waterValue = latestWaterData.value;
+        // Access water data
+        const waterValue = latestWaterData.value;
 
-          if (!this.hasCapability('meter_water')) {
-            promises.push(this.addCapability('meter_water').catch(this.error));
-          }
-          
-          if (this.getCapabilityValue('meter_water') != waterValue)
-                      promises.push(this.setCapabilityValue('meter_water', waterValue).catch(this.error));
+        if (!this.hasCapability('meter_water')) {
+          promises.push(this.addCapability('meter_water').catch(this.error));
+        }
 
-          
-      } else {
-          if (this.hasCapability('meter_water')) {
-                promises.push(this.removeCapability('meter_water').catch(this.error));
-                console.log('Removed meter as there is no water meter in P1.');
-          }
+        if (this.getCapabilityValue('meter_water') != waterValue)
+        { promises.push(this.setCapabilityValue('meter_water', waterValue).catch(this.error)); }
+
+      } else if (this.hasCapability('meter_water')) {
+        promises.push(this.removeCapability('meter_water').catch(this.error));
+        console.log('Removed meter as there is no water meter in P1.');
       }
 
-	  
-
       // Execute all promises concurrently using Promise.all()
-			Promise.all(promises);
+      Promise.all(promises);
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         this.error(err);
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
-}
+};

--- a/drivers/energy/driver.js
+++ b/drivers/energy/driver.js
@@ -10,14 +10,14 @@ module.exports = class HomeWizardEnergyDriver extends Homey.Driver {
     const discoveryStrategy = this.getDiscoveryStrategy();
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const discoveryResults = discoveryStrategy.getDiscoveryResults();
-    await new Promise((resolve) => setTimeout(resolve, 1000)); 
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     const devices = [];
-    await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
+    await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
       try {
         const url = `http://${discoveryResult.address}:${discoveryResult.port}${discoveryResult.txt.path}/data`;
         const res = await fetch(url);
-        if( !res.ok )
-          throw new Error(res.statusText);
+        if (!res.ok)
+        { throw new Error(res.statusText); }
 
         const data = await res.json();
         devices.push({
@@ -25,13 +25,13 @@ module.exports = class HomeWizardEnergyDriver extends Homey.Driver {
           data: {
             id: discoveryResult.id,
           },
-        })
-      } catch( err ) {
+        });
+      } catch (err) {
         this.error(discoveryResult.id, err);
       }
     }));
     return devices;
 
-}
+  }
 
-}
+};

--- a/drivers/energy_socket/device.js
+++ b/drivers/energy_socket/device.js
@@ -13,30 +13,30 @@ module.exports = class HomeWizardEnergySocketDevice extends Homey.Device {
     this.onPollStateInterval = setInterval(this.onPollState.bind(this), POLL_STATE_INTERVAL);
 
     if (this.getClass() == 'sensor') {
-      this.setClass("socket");
+      this.setClass('socket');
     }
 
     this.registerCapabilityListener('onoff', async (value) => {
       if (this.getCapabilityValue('locked'))
-        throw new Error('Device is locked');
+      { throw new Error('Device is locked'); }
 
-      await this.onRequest({"power_on": value});
+      await this.onRequest({ power_on: value });
     });
 
     this.registerCapabilityListener('dim', async (value) => {
-      await this.onRequest({"brightness": (255 * value)});
+      await this.onRequest({ brightness: (255 * value) });
     });
 
     this.registerCapabilityListener('locked', async (value) => {
-      await this.onRequest({"switch_lock": value});
+      await this.onRequest({ switch_lock: value });
     });
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
-    if( this.onPollStateInterval ) {
+    if (this.onPollStateInterval) {
       clearInterval(this.onPollStateInterval);
     }
   }
@@ -61,42 +61,39 @@ module.exports = class HomeWizardEnergySocketDevice extends Homey.Device {
     this.setAvailable();
   }
 
-
-
   async onRequest(body) {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     const res = await fetch(`${this.url}/state`, {
       method: 'PUT',
       body: JSON.stringify(body),
-      headers: {'Content-Type': 'application/json'}
+      headers: { 'Content-Type': 'application/json' },
     }).catch(this.error);
 
-    if( !res.ok )
-      throw new Error(res.statusText);
+    if (!res.ok)
+    { throw new Error(res.statusText); }
   }
 
   onPoll() {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
       //
       let res = await fetch(`${this.url}/data`);
-      
-      if( !res || !res.ok ) {
-        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users 
+
+      if (!res || !res.ok) {
+        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users
         // try again
         res = await fetch(`${this.url}/data`);
-        if( !res || !res.ok )
-          throw new Error(res ? res.statusText : 'Unknown error during fetch');
+        if (!res || !res.ok)
+        { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
       }
 
       const data = await res.json();
 
-      let offset_socket = this.getSetting('offset_socket');
+      const offset_socket = this.getSetting('offset_socket');
 
-      let temp_socket_watt = data.active_power_w + offset_socket;
-
+      const temp_socket_watt = data.active_power_w + offset_socket;
 
       // Save export data check if capabilities are present first
       if (!this.hasCapability('measure_power')) {
@@ -120,82 +117,80 @@ module.exports = class HomeWizardEnergySocketDevice extends Homey.Device {
       }
 
       // Update values
-      //if (this.getCapabilityValue('measure_power') != data.active_power_w)
+      // if (this.getCapabilityValue('measure_power') != data.active_power_w)
       // await this.setCapabilityValue('measure_power', data.active_power_w).catch(this.error);
 
       // Use temp_socket_watt with the compensated value
       if (this.getCapabilityValue('measure_power') != temp_socket_watt)
-       await this.setCapabilityValue('measure_power', temp_socket_watt).catch(this.error);
-
+      { await this.setCapabilityValue('measure_power', temp_socket_watt).catch(this.error); }
 
       if (this.getCapabilityValue('meter_power.consumed.t1') != data.total_power_import_t1_kwh)
-        await this.setCapabilityValue('meter_power.consumed.t1', data.total_power_import_t1_kwh).catch(this.error);
+      { await this.setCapabilityValue('meter_power.consumed.t1', data.total_power_import_t1_kwh).catch(this.error); }
       if (this.getCapabilityValue('measure_power.l1') != data.active_power_l1_w)
-        await this.setCapabilityValue('measure_power.l1', data.active_power_l1_w).catch(this.error);
+      { await this.setCapabilityValue('measure_power.l1', data.active_power_l1_w).catch(this.error); }
       if (this.getCapabilityValue('rssi') != data.wifi_strength)
-        await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error);
+      { await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error); }
 
       // Check to see if there is solar panel production exported if received value is more than 1 it returned back to the power grid
       if (data.total_power_export_t1_kwh > 1) {
-								if (!this.hasCapability('meter_power.produced.t1')) {
-                  // add production meters
-									await this.addCapability('meter_power.produced.t1').catch(this.error);
-								}
-                // update values for solar production
-                if (this.getCapabilityValue('meter_power.produced.t1') != data.total_power_export_t1_kwh)
-								  await this.setCapabilityValue("meter_power.produced.t1", data.total_power_export_t1_kwh).catch(this.error);
-			}
+        if (!this.hasCapability('meter_power.produced.t1')) {
+          // add production meters
+          await this.addCapability('meter_power.produced.t1').catch(this.error);
+        }
+        // update values for solar production
+        if (this.getCapabilityValue('meter_power.produced.t1') != data.total_power_export_t1_kwh)
+								  { await this.setCapabilityValue('meter_power.produced.t1', data.total_power_export_t1_kwh).catch(this.error); }
+      }
       else if (data.total_power_export_t1_kwh < 1) {
-              await this.removeCapability('meter_power.produced.t1').catch(this.error);
+        await this.removeCapability('meter_power.produced.t1').catch(this.error);
       }
 
       // aggregated meter for Power by the hour support
       if (!this.hasCapability('meter_power')) {
-          await this.addCapability('meter_power').catch(this.error);
+        await this.addCapability('meter_power').catch(this.error);
       }
       // update calculated value which is sum of import deducted by the sum of the export this overall kwh number is used for Power by the hour app
-      if (this.getCapabilityValue('meter_power') != (data.total_power_import_t1_kwh-data.total_power_export_t1_kwh))
-        await this.setCapabilityValue('meter_power', (data.total_power_import_t1_kwh-data.total_power_export_t1_kwh)).catch(this.error);
+      if (this.getCapabilityValue('meter_power') != (data.total_power_import_t1_kwh - data.total_power_export_t1_kwh))
+      { await this.setCapabilityValue('meter_power', (data.total_power_import_t1_kwh - data.total_power_export_t1_kwh)).catch(this.error); }
 
-      //active_voltage_l1_v
+      // active_voltage_l1_v
       if (data.active_voltage_v !== undefined) {
         if (!this.hasCapability('measure_voltage')) {
           await this.addCapability('measure_voltage').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_voltage') != data.active_voltage_v)
-        await this.setCapabilityValue("measure_voltage", data.active_voltage_v).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_voltage') != data.active_voltage_v)
+        { await this.setCapabilityValue('measure_voltage', data.active_voltage_v).catch(this.error); }
       }
       else if ((data.active_voltage_v == undefined) && (this.hasCapability('measure_voltage'))) {
         await this.removeCapability('measure_voltage').catch(this.error);
       }
-      
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         if (err.code === 'ECONNRESET') {
           // Handle the ECONNRESET error
           console.log('Connection was reset');
         } else {
-        this.error(err);
+          this.error(err);
         }
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
   onPollState() {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
-      const res = await fetch(`${this.url}/state`).catch(this.error); //Error: Not Found
-      if( !res)
-        throw new Error(res.statusText);
+      const res = await fetch(`${this.url}/state`).catch(this.error); // Error: Not Found
+      if (!res)
+      { throw new Error(res.statusText); }
 
       const data = await res.json();
 
-      let offset_socket = this.getSetting('offset_socket');
+      const offset_socket = this.getSetting('offset_socket');
 
       if (!this.hasCapability('onoff')) {
         await this.addCapability('onoff').catch(this.error);
@@ -211,46 +206,46 @@ module.exports = class HomeWizardEnergySocketDevice extends Homey.Device {
 
       // Update values
       if (this.getCapabilityValue('onoff') != data.power_on)
-        await this.setCapabilityValue('onoff', data.power_on).catch(this.error);
+      { await this.setCapabilityValue('onoff', data.power_on).catch(this.error); }
       if (this.getCapabilityValue('dim') != data.brightness)
-        await this.setCapabilityValue('dim', data.brightness * (1/255)).catch(this.error);
+      { await this.setCapabilityValue('dim', data.brightness * (1 / 255)).catch(this.error); }
       if (this.getCapabilityValue('locked') != data.switch_lock)
-        await this.setCapabilityValue('locked', data.switch_lock).catch(this.error);
+      { await this.setCapabilityValue('locked', data.switch_lock).catch(this.error); }
     })
-    .catch(err => {
-      this.error(err);
-    })
+      .catch((err) => {
+        this.error(err);
+      });
   }
 
   // Catch offset updates
   onSettings(oldSettings, newSettings, changedKeys) {
-    this.log('Settings updated')
+    this.log('Settings updated');
     // Update display values if offset has changed
-    for (let k in changedKeys) {
-      let key = changedKeys[k]
+    for (const k in changedKeys) {
+      const key = changedKeys[k];
       if (key.slice(0, 7) === 'offset_') {
-        let cap = 'measure_' + key.slice(7)
-        let value = this.getCapabilityValue(cap)
-        let delta = newSettings[key] - oldSettings[key]
-        this.log('Updating value of', cap, 'from', value, 'to', value + delta)
+        const cap = `measure_${key.slice(7)}`;
+        const value = this.getCapabilityValue(cap);
+        const delta = newSettings[key] - oldSettings[key];
+        this.log('Updating value of', cap, 'from', value, 'to', value + delta);
         this.setCapabilityValue(cap, value + delta)
-          .catch(err => this.error(err))
+          .catch((err) => this.error(err));
       }
     }
-    //return true;
+    // return true;
   }
 
   updateValue(cap, value) {
     // add offset if defined
-    this.log('Updating value of', this.id, 'with capability', cap, 'to', value)
-    let cap_offset = cap.replace('measure', 'offset')
-    let offset = this.getSetting(cap_offset)
-    this.log(cap_offset, offset)
+    this.log('Updating value of', this.id, 'with capability', cap, 'to', value);
+    const cap_offset = cap.replace('measure', 'offset');
+    const offset = this.getSetting(cap_offset);
+    this.log(cap_offset, offset);
     if (offset != null) {
-      value += offset
+      value += offset;
     }
     this.setCapabilityValue(cap, value)
-      .catch(err => this.error(err))
+      .catch((err) => this.error(err));
   }
 
-}
+};

--- a/drivers/energy_socket/driver.js
+++ b/drivers/energy_socket/driver.js
@@ -7,31 +7,31 @@ module.exports = class HomeWizardEnergySocketDevice extends Homey.Driver {
 
   async onPairListDevices() {
 
-      const discoveryStrategy = this.getDiscoveryStrategy();
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const discoveryResults = discoveryStrategy.getDiscoveryResults();
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const devices = [];
-      await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
-        try {
-          const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
-          const res = await fetch(url);
-          if( !res.ok )
-            throw new Error(res.statusText);
+    const discoveryStrategy = this.getDiscoveryStrategy();
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const discoveryResults = discoveryStrategy.getDiscoveryResults();
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const devices = [];
+    await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
+      try {
+        const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
+        const res = await fetch(url);
+        if (!res.ok)
+        { throw new Error(res.statusText); }
 
-          const data = await res.json();
-          devices.push({
-            name: `${data.product_name} (${data.serial})`,
-            data: {
-              id: discoveryResult.id,
-            },
-          })
-        } catch( err ) {
-          this.error(discoveryResult.id, err);
-        }
-      }));
-      return devices;
+        const data = await res.json();
+        devices.push({
+          name: `${data.product_name} (${data.serial})`,
+          data: {
+            id: discoveryResult.id,
+          },
+        });
+      } catch (err) {
+        this.error(discoveryResult.id, err);
+      }
+    }));
+    return devices;
 
   }
 
-}
+};

--- a/drivers/energy_v2/device.js
+++ b/drivers/energy_v2/device.js
@@ -17,24 +17,23 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
 
   }
 
-  flowTriggerTariff( device, tokens ) {
-    this._flowTriggerTariff.trigger( device, tokens ).catch( this.error )
+  flowTriggerTariff(device, tokens) {
+    this._flowTriggerTariff.trigger(device, tokens).catch(this.error);
   }
 
-  flowTriggerImport( device, tokens ) {
-    this._flowTriggerImport.trigger( device, tokens ).catch( this.error )
+  flowTriggerImport(device, tokens) {
+    this._flowTriggerImport.trigger(device, tokens).catch(this.error);
   }
 
-  flowTriggerExport( device, tokens ) {
-    this._flowTriggerExport.trigger( device, tokens ).catch( this.error )
+  flowTriggerExport(device, tokens) {
+    this._flowTriggerExport.trigger(device, tokens).catch(this.error);
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
   }
-
 
   onDiscoveryAvailable(discoveryResult) {
     this.url = `https://${discoveryResult.address}`;
@@ -55,34 +54,32 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
     this.setAvailable();
     this.onPoll();
   }
+
   onPoll() {
 
     const httpsAgent = new https.Agent({
       rejectUnauthorized: false,
     });
 
-
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
 
-      let token = this.getStoreValue("token")
-      
+      const token = this.getStoreValue('token');
 
-      let res = await fetch(`${this.url}/api/measurement`, {
+      const res = await fetch(`${this.url}/api/measurement`, {
         headers: {
-          'Authorization': `Bearer ${token}`
+          Authorization: `Bearer ${token}`,
         },
-        agent: new (require('https').Agent)({ rejectUnauthorized: false }) // Ignore SSL errors
+        agent: new (require('https').Agent)({ rejectUnauthorized: false }), // Ignore SSL errors
       });
-      
-      if( !res || !res.ok )
-        throw new Error(res ? res.statusText : 'Unknown error during fetch');
 
+      if (!res || !res.ok)
+      { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
 
       const data = await res.json();
 
-//      console.log('Data: ', data);
+      //      console.log('Data: ', data);
 
       const promises = []; // Capture all await promises
 
@@ -91,10 +88,9 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
         promises.push(this.addCapability('measure_power').catch(this.error));
       }
 
-//      if (!this.hasCapability('measure_current.l1') && (data.current_l1_a !== undefined)) {
-//        promises.push(this.addCapability('measure_current.l1').catch(this.error));
-//      }
-
+      //      if (!this.hasCapability('measure_current.l1') && (data.current_l1_a !== undefined)) {
+      //        promises.push(this.addCapability('measure_current.l1').catch(this.error));
+      //      }
 
       if (this.hasCapability('measure_power.power_w')) {
         promises.push(this.removeCapability('measure_power.power_w').catch(this.error));
@@ -109,9 +105,9 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
         promises.push(this.addCapability('meter_power.consumed').catch(this.error));
       }
 
-      //if (!this.hasCapability('rssi')) {
+      // if (!this.hasCapability('rssi')) {
       //  promises.push(this.addCapability('rssi').catch(this.error));
-      //}
+      // }
 
       if (!this.hasCapability('tariff')) {
         promises.push(this.addCapability('tariff').catch(this.error));
@@ -119,24 +115,24 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
 
       // Update values
       if (this.getCapabilityValue('measure_power') != data.power_w)
-      promises.push(this.setCapabilityValue('measure_power', data.power_w).catch(this.error));
-      //if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-      //promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error));
+      { promises.push(this.setCapabilityValue('measure_power', data.power_w).catch(this.error)); }
+      // if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
+      // promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error));
       if (this.getCapabilityValue('meter_power.consumed.t1') != data.energy_import_t1_kwh)
-      promises.push(this.setCapabilityValue('meter_power.consumed.t1', data.energy_import_t1_kwh).catch(this.error));
+      { promises.push(this.setCapabilityValue('meter_power.consumed.t1', data.energy_import_t1_kwh).catch(this.error)); }
       if (this.getCapabilityValue('meter_power.consumed.t2') != data.energy_import_t2_kwh)
-      promises.push(this.setCapabilityValue('meter_power.consumed.t2', data.energy_import_t2_kwh).catch(this.error));
-      //if (this.getCapabilityValue('rssi') != data.wifi_strength)
-      //promises.push(this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error));
+      { promises.push(this.setCapabilityValue('meter_power.consumed.t2', data.energy_import_t2_kwh).catch(this.error)); }
+      // if (this.getCapabilityValue('rssi') != data.wifi_strength)
+      // promises.push(this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error));
       if (this.getCapabilityValue('tariff') != data.tariff)
-      promises.push(this.setCapabilityValue('tariff', data.tariff).catch(this.error));
+      { promises.push(this.setCapabilityValue('tariff', data.tariff).catch(this.error)); }
       if (this.getCapabilityValue('meter_power.consumed') != data.energy_import_kwh)
-      promises.push(this.setCapabilityValue('meter_power.consumed', data.energy_import_kwh).catch(this.error));
+      { promises.push(this.setCapabilityValue('meter_power.consumed', data.energy_import_kwh).catch(this.error)); }
 
-      //Trigger tariff
-      if (data.tariff != this.getStoreValue("last_tariff")) {
+      // Trigger tariff
+      if (data.tariff != this.getStoreValue('last_tariff')) {
         this.flowTriggerTariff(this, { tariff_changed: data.tariff });
-        this.setStoreValue("last_tariff",data.tariff).catch(this.error);
+        this.setStoreValue('last_tariff', data.tariff).catch(this.error);
       }
 
       if (data.current_l1_a !== undefined) {
@@ -144,42 +140,41 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
           promises.push(this.addCapability('measure_current.l1').catch(this.error));
         }
         if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-        promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error));
+        { promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error)); }
       }
       else if (data.current_l1_a == null) {
         // delete measure_current.l1 -> some meters dont have this property
         promises.push(this.removeCapability('measure_current.l1').catch(this.error));
       }
 
-
       // Not all users have a gas meter in their system (if NULL ignore creation or even delete from view)
-      
+
       if (data.total_gas_m3 !== undefined) {
       								if (!this.hasCapability('meter_gas')) {
       									promises.push(this.addCapability('meter_gas').catch(this.error));
       								}
-                      if (this.getCapabilityValue('meter_gas') != data.total_gas_m3)
-                      promises.push(this.setCapabilityValue('meter_gas', data.total_gas_m3).catch(this.error));
+        if (this.getCapabilityValue('meter_gas') != data.total_gas_m3)
+        { promises.push(this.setCapabilityValue('meter_gas', data.total_gas_m3).catch(this.error)); }
       							}
       							else if (data.total_gas_m3 == null) {
-                      // delete gas meter
+        // delete gas meter
       								promises.push(this.removeCapability('meter_gas').catch(this.error));
       }
 
       // Check to see if there is solar panel production exported if received value is more than 1 it returned back to the power grid
       if ((data.energy_export_t1_kwh > 1) || (data.energy_export_t2_kwh > 1)) {
-								if ((!this.hasCapability('meter_power.produced.t1')) || (!this.hasCapability('meter_power.returned'))) {
-                  // add production meters
-									promises.push(this.addCapability('meter_power.produced.t1').catch(this.error));
-									promises.push(this.addCapability('meter_power.produced.t2').catch(this.error));
-                  promises.push(this.addCapability('meter_power.returned').catch(this.error));
-								}
-                // update values for solar production
-                if (this.getCapabilityValue('meter_power.produced.t1') != data.energy_export_t1_kwh)
-                promises.push(this.setCapabilityValue("meter_power.produced.t1", data.energy_export_t1_kwh).catch(this.error));
-                if (this.getCapabilityValue('meter_power.produced.t2') != data.energy_export_t2_kwh)
-                promises.push(this.setCapabilityValue("meter_power.produced.t2", data.energy_export_t1_kwh).catch(this.error));
-			}
+        if ((!this.hasCapability('meter_power.produced.t1')) || (!this.hasCapability('meter_power.returned'))) {
+          // add production meters
+          promises.push(this.addCapability('meter_power.produced.t1').catch(this.error));
+          promises.push(this.addCapability('meter_power.produced.t2').catch(this.error));
+          promises.push(this.addCapability('meter_power.returned').catch(this.error));
+        }
+        // update values for solar production
+        if (this.getCapabilityValue('meter_power.produced.t1') != data.energy_export_t1_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.produced.t1', data.energy_export_t1_kwh).catch(this.error)); }
+        if (this.getCapabilityValue('meter_power.produced.t2') != data.energy_export_t2_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.produced.t2', data.energy_export_t1_kwh).catch(this.error)); }
+      }
       else if ((data.energy_export_t1_kwh < 1) || (data.energy_export_t2_kwh < 1)) {
         promises.push(this.removeCapability('meter_power.produced.t1').catch(this.error));
         promises.push(this.removeCapability('meter_power.produced.t2').catch(this.error));
@@ -192,200 +187,200 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
       // update calculated value which is sum of import deducted by the sum of the export this overall kwh number is used for Power by the hour app
       // Pre P1 firmware 4.x
       if (data.energy_import_kwh === undefined) {
-        if (this.getCapabilityValue('meter_power') != ((data.energy_import_t1_kwh+data.energy_import_t2_kwh)-(data.energy_export_t1_kwh+data.energy_export_t2_kwh)))
-        promises.push(this.setCapabilityValue('meter_power', ((data.energy_import_t1_kwh+data.energy_import_t2_kwh)-(data.energy_export_t1_kwh+data.energy_export_t2_kwh))).catch(this.error));
+        if (this.getCapabilityValue('meter_power') != ((data.energy_import_t1_kwh + data.energy_import_t2_kwh) - (data.energy_export_t1_kwh + data.energy_export_t2_kwh)))
+        { promises.push(this.setCapabilityValue('meter_power', ((data.energy_import_t1_kwh + data.energy_import_t2_kwh) - (data.energy_export_t1_kwh + data.energy_export_t2_kwh))).catch(this.error)); }
       }
       // P1 Firmwmare 4.x and later
       else if (data.energy_import_kwh !== undefined) {
-        if (this.getCapabilityValue('meter_power') != (data.energy_import_kwh-data.energy_export_kwh))
-        promises.push(this.setCapabilityValue('meter_power', (data.energy_import_kwh-data.energy_export_kwh)).catch(this.error));
+        if (this.getCapabilityValue('meter_power') != (data.energy_import_kwh - data.energy_export_kwh))
+        { promises.push(this.setCapabilityValue('meter_power', (data.energy_import_kwh - data.energy_export_kwh)).catch(this.error)); }
         if (this.getCapabilityValue('meter_power.returned') != data.energy_export_kwh)
-        promises.push(this.setCapabilityValue('meter_power.returned', data.energy_export_kwh).catch(this.error));
+        { promises.push(this.setCapabilityValue('meter_power.returned', data.energy_export_kwh).catch(this.error)); }
       }
 
-      //Trigger import
-      if (data.energy_import_kwh != this.getStoreValue("last_total_import_kwh")) {
+      // Trigger import
+      if (data.energy_import_kwh != this.getStoreValue('last_total_import_kwh')) {
         this.flowTriggerImport(this, { import_changed: data.energy_import_kwh });
-        this.setStoreValue("last_total_import_kwh",data.energy_import_kwh).catch(this.error);
-     }
+        this.setStoreValue('last_total_import_kwh', data.energy_import_kwh).catch(this.error);
+      }
 
-      //Trigger export
-      if (data.energy_export_kwh != this.getStoreValue("last_total_export_kwh")) {
+      // Trigger export
+      if (data.energy_export_kwh != this.getStoreValue('last_total_export_kwh')) {
         this.flowTriggerExport(this, { export_changed: data.energy_export_kwh });
-        this.setStoreValue("last_total_export_kwh",data.energy_export_kwh).catch(this.error);
-     }
+        this.setStoreValue('last_total_export_kwh', data.energy_export_kwh).catch(this.error);
+      }
 
-      //Belgium 
+      // Belgium
       if (data.montly_power_peak_w !== undefined) {
         if (!this.hasCapability('measure_power.montly_power_peak')) {
           promises.push(this.addCapability('measure_power.montly_power_peak').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.montly_power_peak') != data.montly_power_peak_w)
-      promises.push(this.setCapabilityValue("measure_power.montly_power_peak", data.montly_power_peak_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.montly_power_peak') != data.montly_power_peak_w)
+        { promises.push(this.setCapabilityValue('measure_power.montly_power_peak', data.montly_power_peak_w).catch(this.error)); }
       }
       else if ((data.montly_power_peak_w == undefined) && (this.hasCapability('measure_power.montly_power_peak'))) {
         promises.push(this.removeCapability('measure_power.montly_power_peak').catch(this.error));
       }
 
-      //voltage_l1_v Some P1 meters do have voltage data
+      // voltage_l1_v Some P1 meters do have voltage data
       if (data.voltage_l1_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l1')) {
           promises.push(this.addCapability('measure_voltage.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l1') != data.voltage_l1_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l1", data.voltage_l1_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l1') != data.voltage_l1_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l1', data.voltage_l1_v).catch(this.error)); }
       }
       else if ((data.voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
         promises.push(this.removeCapability('measure_voltage.l1').catch(this.error));
       }
 
-      //current_l1_a Some P1 meters do have amp data
+      // current_l1_a Some P1 meters do have amp data
       if (data.current_l1_a !== undefined) {
         if (!this.hasCapability('measure_current.l1')) {
           promises.push(this.addCapability('measure_current.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-      promises.push(this.setCapabilityValue("measure_current.l1", data.current_l1_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
+        { promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error)); }
       }
       else if ((data.current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
         promises.push(this.removeCapability('measure_current.l1').catch(this.error));
       }
 
-      //Power failure count - long_power_fail_count
+      // Power failure count - long_power_fail_count
       if (data.long_power_fail_count !== undefined) {
         if (!this.hasCapability('long_power_fail_count')) {
           promises.push(this.addCapability('long_power_fail_count').catch(this.error));
-      }
-      if (this.getCapabilityValue('long_power_fail_count') != data.long_power_fail_count)
-      promises.push(this.setCapabilityValue("long_power_fail_count", data.long_power_fail_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('long_power_fail_count') != data.long_power_fail_count)
+        { promises.push(this.setCapabilityValue('long_power_fail_count', data.long_power_fail_count).catch(this.error)); }
       }
       else if ((data.long_power_fail_count == undefined) && (this.hasCapability('long_power_fail_count'))) {
         promises.push(this.removeCapability('long_power_fail_count').catch(this.error));
       }
 
-      //voltage_sag_l1_count - Net L1 dip 
+      // voltage_sag_l1_count - Net L1 dip
       if (data.voltage_sag_l1_count !== undefined) {
         if (!this.hasCapability('voltage_sag_l1')) {
           promises.push(this.addCapability('voltage_sag_l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_sag_l1') != data.voltage_sag_l1_count)
-      promises.push(this.setCapabilityValue("voltage_sag_l1", data.voltage_sag_l1_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_sag_l1') != data.voltage_sag_l1_count)
+        { promises.push(this.setCapabilityValue('voltage_sag_l1', data.voltage_sag_l1_count).catch(this.error)); }
       }
       else if ((data.voltage_sag_l1_count == undefined) && (this.hasCapability('voltage_sag_l1'))) {
         promises.push(this.removeCapability('voltage_sag_l1').catch(this.error));
       }
 
-      //voltage_sag_l2_count - Net L2 dip 
+      // voltage_sag_l2_count - Net L2 dip
       if (data.voltage_sag_l2_count !== undefined) {
         if (!this.hasCapability('voltage_sag_l2')) {
           promises.push(this.addCapability('voltage_sag_l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_sag_l2') != data.voltage_sag_l2_count)
-      promises.push(this.setCapabilityValue("voltage_sag_l2", data.voltage_sag_l2_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_sag_l2') != data.voltage_sag_l2_count)
+        { promises.push(this.setCapabilityValue('voltage_sag_l2', data.voltage_sag_l2_count).catch(this.error)); }
       }
       else if ((data.voltage_sag_l2_count == undefined) && (this.hasCapability('voltage_sag_l2'))) {
         promises.push(this.removeCapability('voltage_sag_l2').catch(this.error));
       }
 
-      //voltage_sag_l3_count - Net L3 dip 
+      // voltage_sag_l3_count - Net L3 dip
       if (data.voltage_sag_l3_count !== undefined) {
         if (!this.hasCapability('voltage_sag_l3')) {
           promises.push(this.addCapability('voltage_sag_l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_sag_l3') != data.voltage_sag_l3_count)
-      promises.push(this.setCapabilityValue("voltage_sag_l3", data.voltage_sag_l3_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_sag_l3') != data.voltage_sag_l3_count)
+        { promises.push(this.setCapabilityValue('voltage_sag_l3', data.voltage_sag_l3_count).catch(this.error)); }
       }
       else if ((data.voltage_sag_l3_count == undefined) && (this.hasCapability('voltage_sag_l3'))) {
         promises.push(this.removeCapability('voltage_sag_l3').catch(this.error));
       }
-      
-       //voltage_swell_l1_count - Net L1 peak 
-       if (data.voltage_swell_l1_count !== undefined) {
+
+      // voltage_swell_l1_count - Net L1 peak
+      if (data.voltage_swell_l1_count !== undefined) {
         if (!this.hasCapability('voltage_swell_l1')) {
           promises.push(this.addCapability('voltage_swell_l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_swell_l1') != data.voltage_swell_l1_count)
-      promises.push(this.setCapabilityValue("voltage_swell_l1", data.voltage_swell_l1_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_swell_l1') != data.voltage_swell_l1_count)
+        { promises.push(this.setCapabilityValue('voltage_swell_l1', data.voltage_swell_l1_count).catch(this.error)); }
       }
       else if ((data.voltage_swell_l1_count == undefined) && (this.hasCapability('voltage_swell_l1'))) {
         promises.push(this.removeCapability('voltage_swell_l1').catch(this.error));
       }
 
-      //voltage_swell_l2_count - Net L2 peak 
+      // voltage_swell_l2_count - Net L2 peak
       if (data.voltage_swell_l2_count !== undefined) {
         if (!this.hasCapability('voltage_swell_l2')) {
           promises.push(this.addCapability('voltage_swell_l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_swell_l2') != data.voltage_swell_l2_count)
-      promises.push(this.setCapabilityValue("voltage_swell_l2", data.voltage_swell_l2_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_swell_l2') != data.voltage_swell_l2_count)
+        { promises.push(this.setCapabilityValue('voltage_swell_l2', data.voltage_swell_l2_count).catch(this.error)); }
       }
       else if ((data.voltage_swell_l2_count == undefined) && (this.hasCapability('voltage_swell_l2'))) {
         promises.push(this.removeCapability('voltage_swell_l2').catch(this.error));
       }
 
-      //voltage_swell_l3_count - Net L3 peak 
+      // voltage_swell_l3_count - Net L3 peak
       if (data.voltage_swell_l3_count !== undefined) {
         if (!this.hasCapability('voltage_swell_l3')) {
           promises.push(this.addCapability('voltage_swell_l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('voltage_swell_l3') != data.voltage_swell_l3_count)
-      promises.push(this.setCapabilityValue("voltage_swell_l3", data.voltage_swell_l3_count).catch(this.error));
+        }
+        if (this.getCapabilityValue('voltage_swell_l3') != data.voltage_swell_l3_count)
+        { promises.push(this.setCapabilityValue('voltage_swell_l3', data.voltage_swell_l3_count).catch(this.error)); }
       }
       else if ((data.voltage_swell_l3_count == undefined) && (this.hasCapability('voltage_swell_l3'))) {
         promises.push(this.removeCapability('voltage_swell_l3').catch(this.error));
       }
 
-      //Rewrite of L1/L2/L3 Voltage/Amp
+      // Rewrite of L1/L2/L3 Voltage/Amp
       if (data.power_l1_w !== undefined) {
         if (!this.hasCapability('measure_power.l1')) {
           promises.push(this.addCapability('measure_power.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.l1') != data.power_l1_w)
-          promises.push(this.setCapabilityValue("measure_power.l1", data.power_l1_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.l1') != data.power_l1_w)
+        { promises.push(this.setCapabilityValue('measure_power.l1', data.power_l1_w).catch(this.error)); }
       }
       else if ((data.power_l1_w == undefined) && (this.hasCapability('measure_power.l1'))) {
         promises.push(this.removeCapability('measure_power.l1').catch(this.error));
       }
-	  
+
       if (data.power_l2_w !== undefined) {
         if (!this.hasCapability('measure_power.l2')) {
           promises.push(this.addCapability('measure_power.l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.l2') != data.power_l2_w)
-      promises.push(this.setCapabilityValue("measure_power.l2", data.power_l2_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.l2') != data.power_l2_w)
+        { promises.push(this.setCapabilityValue('measure_power.l2', data.power_l2_w).catch(this.error)); }
       }
       else if ((data.power_l2_w == undefined) && (this.hasCapability('measure_power.l2'))) {
         promises.push(this.removeCapability('measure_power.l2').catch(this.error));
       }
-	  
+
       if (data.power_l3_w !== undefined) {
         if (!this.hasCapability('measure_power.l3')) {
           promises.push(this.addCapability('measure_power.l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_power.l3') != data.power_l3_w)
-      promises.push(this.setCapabilityValue("measure_power.l3", data.power_l3_w).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_power.l3') != data.power_l3_w)
+        { promises.push(this.setCapabilityValue('measure_power.l3', data.power_l3_w).catch(this.error)); }
       }
       else if ((data.power_l3_w == undefined) && (this.hasCapability('measure_power.l3'))) {
         promises.push(this.removeCapability('measure_power.l3').catch(this.error));
       }
-	  
+
       if (data.voltage_l1_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l1')) {
           promises.push(this.addCapability('measure_voltage.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l1') != data.voltage_l1_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l1", data.voltage_l1_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l1') != data.voltage_l1_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l1', data.voltage_l1_v).catch(this.error)); }
       }
       else if ((data.voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
         promises.push(this.removeCapability('measure_voltage.l1').catch(this.error));
       }
-	  
+
       if (data.voltage_l2_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l2')) {
           promises.push(this.addCapability('measure_voltage.l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l2') != data.voltage_l2_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l2", data.voltage_l2_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l2') != data.voltage_l2_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l2', data.voltage_l2_v).catch(this.error)); }
       }
       else if ((data.voltage_l2_v == undefined) && (this.hasCapability('measure_voltage.l2'))) {
         promises.push(this.removeCapability('measure_voltage.l2').catch(this.error));
@@ -394,54 +389,54 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
       if (data.voltage_l3_v !== undefined) {
         if (!this.hasCapability('measure_voltage.l3')) {
           promises.push(this.addCapability('measure_voltage.l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_voltage.l3') != data.voltage_l3_v)
-      promises.push(this.setCapabilityValue("measure_voltage.l3", data.voltage_l3_v).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_voltage.l3') != data.voltage_l3_v)
+        { promises.push(this.setCapabilityValue('measure_voltage.l3', data.voltage_l3_v).catch(this.error)); }
       }
       else if ((data.voltage_l3_v == undefined) && (this.hasCapability('measure_voltage.l3'))) {
         promises.push(this.removeCapability('measure_voltage.l3').catch(this.error));
       }
-	  
+
       if (data.current_l1_a !== undefined) {
         if (!this.hasCapability('measure_current.l1')) {
           promises.push(this.addCapability('measure_current.l1').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-      promises.push(this.setCapabilityValue("measure_current.l1", data.current_l1_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
+        { promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error)); }
       }
       else if ((data.current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
         promises.push(this.removeCapability('measure_current.l1').catch(this.error));
       }
-	  
+
       if (data.current_l2_a !== undefined) {
         if (!this.hasCapability('measure_current.l2')) {
           promises.push(this.addCapability('measure_current.l2').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l2') != data.current_l2_a)
-      promises.push(this.setCapabilityValue("measure_current.l2", data.current_l2_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l2') != data.current_l2_a)
+        { promises.push(this.setCapabilityValue('measure_current.l2', data.current_l2_a).catch(this.error)); }
       }
       else if ((data.current_l2_a == undefined) && (this.hasCapability('measure_current.l2'))) {
         promises.push(this.removeCapability('measure_current.l2').catch(this.error));
       }
-	  
+
       if (data.current_l3_a !== undefined) {
         if (!this.hasCapability('measure_current.l3')) {
           promises.push(this.addCapability('measure_current.l3').catch(this.error));
-      }
-      if (this.getCapabilityValue('measure_current.l3') != data.current_l3_a)
-      promises.push(this.setCapabilityValue("measure_current.l3", data.current_l3_a).catch(this.error));
+        }
+        if (this.getCapabilityValue('measure_current.l3') != data.current_l3_a)
+        { promises.push(this.setCapabilityValue('measure_current.l3', data.current_l3_a).catch(this.error)); }
       }
       else if ((data.current_l3_a == undefined) && (this.hasCapability('measure_current.l3'))) {
         promises.push(this.removeCapability('measure_current.l3').catch(this.error));
       }
-	  
-      //T3 meter request import and export
+
+      // T3 meter request import and export
       if (data.total_power_import_t3_kwh !== undefined) {
         if (!this.hasCapability('meter_power.consumed.t3')) {
           promises.push(this.addCapability('meter_power.consumed.t3').catch(this.error));
-      }
-      if (this.getCapabilityValue('meter_power.consumed.t3') != data.total_power_import_t3_kwh)
-      promises.push(this.setCapabilityValue("meter_power.consumed.t3", data.total_power_import_t3_kwh).catch(this.error));
+        }
+        if (this.getCapabilityValue('meter_power.consumed.t3') != data.total_power_import_t3_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.consumed.t3', data.total_power_import_t3_kwh).catch(this.error)); }
       }
       else if ((data.total_power_import_t3_kwh == undefined) && (this.hasCapability('meter_power.consumed.t3'))) {
         promises.push(this.removeCapability('meter_power.consumed.t3').catch(this.error));
@@ -450,9 +445,9 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
       if (data.total_power_export_t3_kwh !== undefined) {
         if (!this.hasCapability('meter_power.produced.t3')) {
           promises.push(this.addCapability('meter_power.produced.t3').catch(this.error));
-      }
-      if (this.getCapabilityValue('meter_power.produced.t3') != data.total_power_export_t3_kwh)
-      promises.push(this.setCapabilityValue("meter_power.produced.t3", data.total_power_export_t3_kwh).catch(this.error));
+        }
+        if (this.getCapabilityValue('meter_power.produced.t3') != data.total_power_export_t3_kwh)
+        { promises.push(this.setCapabilityValue('meter_power.produced.t3', data.total_power_export_t3_kwh).catch(this.error)); }
       }
       else if ((data.total_power_export_t3_kwh == undefined) && (this.hasCapability('meter_power.produced.t3'))) {
         promises.push(this.removeCapability('meter_power.produced.t3').catch(this.error));
@@ -465,49 +460,44 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
       let latestWaterData = null;
       if (externalData && externalData.length > 0) {
 
-          // Find the water data with the latest timestamp
-          latestWaterData = externalData.reduce((prev, current) => {
-              if (current.type === 'water_meter') {
-                  if (!prev || current.timestamp > prev.timestamp) {
-                      return current;
-                  }
-              }
-              return prev;
-          }, null);
+        // Find the water data with the latest timestamp
+        latestWaterData = externalData.reduce((prev, current) => {
+          if (current.type === 'water_meter') {
+            if (!prev || current.timestamp > prev.timestamp) {
+              return current;
+            }
+          }
+          return prev;
+        }, null);
       }
 
       if (latestWaterData) {
-          // Access water data
-          const waterValue = latestWaterData.value;
+        // Access water data
+        const waterValue = latestWaterData.value;
 
-          if (!this.hasCapability('meter_water')) {
-            promises.push(this.addCapability('meter_water').catch(this.error));
-          }
-          
-          if (this.getCapabilityValue('meter_water') != waterValue)
-                      promises.push(this.setCapabilityValue('meter_water', waterValue).catch(this.error));
+        if (!this.hasCapability('meter_water')) {
+          promises.push(this.addCapability('meter_water').catch(this.error));
+        }
 
-          
-      } else {
-          if (this.hasCapability('meter_water')) {
-                promises.push(this.removeCapability('meter_water').catch(this.error));
-                console.log('Removed meter as there is no water meter in P1.');
-          }
+        if (this.getCapabilityValue('meter_water') != waterValue)
+        { promises.push(this.setCapabilityValue('meter_water', waterValue).catch(this.error)); }
+
+      } else if (this.hasCapability('meter_water')) {
+        promises.push(this.removeCapability('meter_water').catch(this.error));
+        console.log('Removed meter as there is no water meter in P1.');
       }
 
-	  
-
       // Execute all promises concurrently using Promise.all()
-			Promise.all(promises);
+      Promise.all(promises);
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         this.error(err);
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
-}
+};

--- a/drivers/energy_v2/driver.js
+++ b/drivers/energy_v2/driver.js
@@ -8,82 +8,81 @@ module.exports = class HomeWizardEnergyDriverV2 extends Homey.Driver {
 
   async onPair(session) {
 
-    session.setHandler("list_devices", async () => {
+    session.setHandler('list_devices', async () => {
 
-            const httpsAgent = new https.Agent({
-              rejectUnauthorized: false, //ignore SSL errors
-            });
-        
-            const discoveryStrategy = this.getDiscoveryStrategy();
-            const discoveryResults = discoveryStrategy.getDiscoveryResults();
-            const devices = [];
-            await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
-              try {
-        
-                // start.html -> Confirmation pressing button on device
-                const payload = {
-                  name: 'local/homey_user'
-                };
-                
-                const response  = await fetch(`https://${discoveryResult.address}/api/user`, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'X-Api-Version': '2'
-                  },
-                  body: JSON.stringify(payload),
-                  agent: new (require('https').Agent)({ rejectUnauthorized: false }),
-                  
-                });
-        
-                //if (!response.ok) {
-                //  throw new Error(`Error: ${response.statusText}`);
-                //}
-        
-        
-                const result = await response.json();
-                console.log("Result received: ", result);
-        
-                //const responseData = await result.json();
-                const bearer_token = result.token;
-        
-                console.log("Bearer token: ", result.token);
-                
-                const res = await fetch(`https://${discoveryResult.address}/api/measurement`, {
-                  headers: {
-                    'Authorization': `Bearer ${bearer_token}`
-                  },
-                  agent: new (require('https').Agent)({ rejectUnauthorized: false }) // Ignore SSL errors
-                });
-        
-                if( !res.ok )
-                  throw new Error(res.statusText);
-        
-                const data = await res.json();
-        
-                devices.push({
-                  name: data.meter_model,
-                  data: {
-                    id: discoveryResult.id,
-                  },
-                  store: {
-                    token: bearer_token,
-                  }
-                })
-              } catch( err ) {
-                this.error(discoveryResult.id, err);
-              }
-            }));
-            return devices;
+      const httpsAgent = new https.Agent({
+        rejectUnauthorized: false, // ignore SSL errors
+      });
+
+      const discoveryStrategy = this.getDiscoveryStrategy();
+      const discoveryResults = discoveryStrategy.getDiscoveryResults();
+      const devices = [];
+      await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
+        try {
+
+          // start.html -> Confirmation pressing button on device
+          const payload = {
+            name: 'local/homey_user',
+          };
+
+          const response = await fetch(`https://${discoveryResult.address}/api/user`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Api-Version': '2',
+            },
+            body: JSON.stringify(payload),
+            agent: new (require('https').Agent)({ rejectUnauthorized: false }),
+
           });
 
-          session.setHandler('showView', async (view) => {
-            if (view === 'loading') {
-              
-              await session.nextView();
-            }
+          // if (!response.ok) {
+          //  throw new Error(`Error: ${response.statusText}`);
+          // }
+
+          const result = await response.json();
+          console.log('Result received: ', result);
+
+          // const responseData = await result.json();
+          const bearer_token = result.token;
+
+          console.log('Bearer token: ', result.token);
+
+          const res = await fetch(`https://${discoveryResult.address}/api/measurement`, {
+            headers: {
+              Authorization: `Bearer ${bearer_token}`,
+            },
+            agent: new (require('https').Agent)({ rejectUnauthorized: false }), // Ignore SSL errors
           });
 
-}
+          if (!res.ok)
+          { throw new Error(res.statusText); }
 
-}
+          const data = await res.json();
+
+          devices.push({
+            name: data.meter_model,
+            data: {
+              id: discoveryResult.id,
+            },
+            store: {
+              token: bearer_token,
+            },
+          });
+        } catch (err) {
+          this.error(discoveryResult.id, err);
+        }
+      }));
+      return devices;
+    });
+
+    session.setHandler('showView', async (view) => {
+      if (view === 'loading') {
+
+        await session.nextView();
+      }
+    });
+
+  }
+
+};

--- a/drivers/energylink/device.js
+++ b/drivers/energylink/device.js
@@ -1,416 +1,408 @@
 'use strict';
 
 const Homey = require('homey');
-const homewizard = require('./../../includes/homewizard.js');
+const homewizard = require('../../includes/homewizard.js');
 
 const debug = false;
 
-var refreshIntervalId;
-var refreshIntervalIdReadings;
+let refreshIntervalId;
+let refreshIntervalIdReadings;
 
 class HomeWizardEnergylink extends Homey.Device {
 
-	onInit() {
+  onInit() {
 
-		console.log('HomeWizard Energylink: "'+this.getName() +'" has been added'); 
+    console.log(`HomeWizard Energylink: "${this.getName()}" has been added`);
 
-		this.startPolling();
+    this.startPolling();
 
-		// Init flow triggers
-		this._flowTriggerPowerUsed = this.homey.flow.getDeviceTriggerCard('power_used_changed');
-		this._flowTriggerPowerNetto = this.homey.flow.getDeviceTriggerCard('power_netto_changed');
-		this._flowTriggerPowerS1 = this.homey.flow.getDeviceTriggerCard('power_s1_changed');
-		this._flowTriggerMeterPowerS1 = this.homey.flow.getDeviceTriggerCard('meter_power_s1_changed');
-		this._flowTriggerPowerS2 = this.homey.flow.getDeviceTriggerCard('power_s2_changed');
-		this._flowTriggerMeterPowerS2 = this.homey.flow.getDeviceTriggerCard('meter_power_s2_changed');
-		this._flowTriggerMeterPowerUsed = this.homey.flow.getDeviceTriggerCard('meter_power_used_changed');
-		this._flowTriggerMeterPowerAggregated = this.homey.flow.getDeviceTriggerCard('meter_power_aggregated_changed');
-		this._flowTriggerMeterReturnT1 = this.homey.flow.getDeviceTriggerCard('meter_return_t1_changed');
-		this._flowTriggerMeterReturnT2 = this.homey.flow.getDeviceTriggerCard('meter_return_t2_changed');
+    // Init flow triggers
+    this._flowTriggerPowerUsed = this.homey.flow.getDeviceTriggerCard('power_used_changed');
+    this._flowTriggerPowerNetto = this.homey.flow.getDeviceTriggerCard('power_netto_changed');
+    this._flowTriggerPowerS1 = this.homey.flow.getDeviceTriggerCard('power_s1_changed');
+    this._flowTriggerMeterPowerS1 = this.homey.flow.getDeviceTriggerCard('meter_power_s1_changed');
+    this._flowTriggerPowerS2 = this.homey.flow.getDeviceTriggerCard('power_s2_changed');
+    this._flowTriggerMeterPowerS2 = this.homey.flow.getDeviceTriggerCard('meter_power_s2_changed');
+    this._flowTriggerMeterPowerUsed = this.homey.flow.getDeviceTriggerCard('meter_power_used_changed');
+    this._flowTriggerMeterPowerAggregated = this.homey.flow.getDeviceTriggerCard('meter_power_aggregated_changed');
+    this._flowTriggerMeterReturnT1 = this.homey.flow.getDeviceTriggerCard('meter_return_t1_changed');
+    this._flowTriggerMeterReturnT2 = this.homey.flow.getDeviceTriggerCard('meter_return_t2_changed');
 
-	}
+  }
 
-	flowTriggerPowerUsed( device, tokens ) {
-		this._flowTriggerPowerUsed.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerPowerUsed(device, tokens) {
+    this._flowTriggerPowerUsed.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerPowerNetto( device, tokens ) {
-		this._flowTriggerPowerNetto.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerPowerNetto(device, tokens) {
+    this._flowTriggerPowerNetto.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerPowerS1( device, tokens ) {
-		this._flowTriggerPowerS1.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerPowerS1(device, tokens) {
+    this._flowTriggerPowerS1.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerMeterPowerS1( device, tokens ) {
-		this._flowTriggerMeterPowerS1.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerMeterPowerS1(device, tokens) {
+    this._flowTriggerMeterPowerS1.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerPowerS2( device, tokens ) {
-		this._flowTriggerPowerS2.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerPowerS2(device, tokens) {
+    this._flowTriggerPowerS2.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerMeterPowerS2( device, tokens ) {
-		this._flowTriggerMeterPowerS2.trigger( device, tokens ).catch( this.error )
-	}
-	flowTriggerMeterPowerUsed( device, tokens ) {
-		this._flowTriggerMeterPowerUsed.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerMeterPowerS2(device, tokens) {
+    this._flowTriggerMeterPowerS2.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerMeterPowerAggregated( device, tokens ) {
-		this._flowTriggerMeterPowerAggregated.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerMeterPowerUsed(device, tokens) {
+    this._flowTriggerMeterPowerUsed.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerMeterReturnT1( device, tokens ) {
-		this._flowTriggerMeterReturnT1.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerMeterPowerAggregated(device, tokens) {
+    this._flowTriggerMeterPowerAggregated.trigger(device, tokens).catch(this.error);
+  }
 
-	flowTriggerMeterReturnT2( device, tokens ) {
-		this._flowTriggerMeterReturnT2.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerMeterReturnT1(device, tokens) {
+    this._flowTriggerMeterReturnT1.trigger(device, tokens).catch(this.error);
+  }
 
-	startPolling() {
+  flowTriggerMeterReturnT2(device, tokens) {
+    this._flowTriggerMeterReturnT2.trigger(device, tokens).catch(this.error);
+  }
 
-		// Clear interval
-		if (this.refreshIntervalId) {
-				clearInterval(this.refreshIntervalId);
-		}
+  startPolling() {
 
-		this.refreshIntervalId = setInterval(() => {
+    // Clear interval
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
 
-			if (debug) {console.log("--Start Energylink Polling-- ");}
-			if (debug) {console.log(this.getSetting('homewizard_id'));}
-			if(this.getSetting('homewizard_id') !== undefined ) {
-				if (debug) {console.log('Poll for '+this.getName());}
+    this.refreshIntervalId = setInterval(() => {
 
-				this.getStatus();
-			}
+      if (debug) { console.log('--Start Energylink Polling-- '); }
+      if (debug) { console.log(this.getSetting('homewizard_id')); }
+      if (this.getSetting('homewizard_id') !== undefined) {
+        if (debug) { console.log(`Poll for ${this.getName()}`); }
 
-		}, 1000 * 20);
+        this.getStatus();
+      }
 
-		// Clear interval
-		if (this.refreshIntervalIdReadings) {
-					clearInterval(this.refreshIntervalIdReadings);
-		}
+    }, 1000 * 20);
 
-		this.refreshIntervalIdReadings = setInterval(() => {
-			if (debug) {console.log("--Start Energylink Readings Polling-- ");}
+    // Clear interval
+    if (this.refreshIntervalIdReadings) {
+      clearInterval(this.refreshIntervalIdReadings);
+    }
 
-			if(this.getSetting('homewizard_id') !== undefined ) {
-				if (debug) {console.log('Poll for ' + this.getName());}
+    this.refreshIntervalIdReadings = setInterval(() => {
+      if (debug) { console.log('--Start Energylink Readings Polling-- '); }
 
-				this.getReadings();
+      if (this.getSetting('homewizard_id') !== undefined) {
+        if (debug) { console.log(`Poll for ${this.getName()}`); }
 
-			}
-		}, 1000 * 60);
+        this.getReadings();
 
-	}
+      }
+    }, 1000 * 60);
 
+  }
 
-	async getStatus() {
-		
-		const homewizard_id = this.getSetting('homewizard_id');
+  async getStatus() {
 
-		const me = this;
+    const homewizard_id = this.getSetting('homewizard_id');
 
-//		homewizard.getDeviceData(homewizard_id, 'energylinks', async function(callback){
-		const callback = await homewizard.getDeviceData(homewizard_id, 'energylinks');
-		try {
+    const me = this;
 
-			if (Object.keys(callback).length > 0) {
+    //		homewizard.getDeviceData(homewizard_id, 'energylinks', async function(callback){
+    const callback = await homewizard.getDeviceData(homewizard_id, 'energylinks');
+    try {
 
-			//	try {
+      if (Object.keys(callback).length > 0) {
 
-					me.setAvailable();
+        //	try {
 
-					const promises = []; 
+        me.setAvailable();
 
-					let value_s1 = ( callback[0].t1 ) ; // Read t1 from energylink (solar/water/null)
-					let value_s2 = ( callback[0].t2 ) ; // Read t2 from energylink (solar/water/null)
-					if (debug) {console.log("t1- " + value_s1);}
-					if (debug) {console.log("t2- " + value_s2);}
+        const promises = [];
 
-					// Common Energylink data
-					let energy_current_cons = ( callback[0].used.po ); // WATTS Energy used JSON $energylink[0]['used']['po']
-					let energy_daytotal_cons = ( callback[0].used.dayTotal ); // KWH Energy used JSON $energylink[0]['used']['dayTotal']
-					let energy_daytotal_aggr = ( callback[0].aggregate.dayTotal ) ; // KWH Energy aggregated is used - generated $energylink[0]['aggregate']['dayTotal']
-					let energy_current_netto = ( callback[0].aggregate.po ); // Netto power usage from aggregated value, this value can go negative
+        const value_s1 = (callback[0].t1); // Read t1 from energylink (solar/water/null)
+        const value_s2 = (callback[0].t2); // Read t2 from energylink (solar/water/null)
+        if (debug) { console.log(`t1- ${value_s1}`); }
+        if (debug) { console.log(`t2- ${value_s2}`); }
 
-					// Some Energylink do not have gas information so try to get it else fail silently
-					try {
-						let gas_daytotal_cons = ( callback[0].gas.dayTotal ); // m3 Energy produced via S1 $energylink[0]['gas']['dayTotal']
-						// Consumed gas
-						await me.setCapabilityValue("meter_gas.today", gas_daytotal_cons).catch(me.error);
-					}
-					catch(err) {
-						// Error with Energylink no data in Energylink
-						console.log ("No Gas information found");
-					}
+        // Common Energylink data
+        const energy_current_cons = (callback[0].used.po); // WATTS Energy used JSON $energylink[0]['used']['po']
+        const energy_daytotal_cons = (callback[0].used.dayTotal); // KWH Energy used JSON $energylink[0]['used']['dayTotal']
+        const energy_daytotal_aggr = (callback[0].aggregate.dayTotal); // KWH Energy aggregated is used - generated $energylink[0]['aggregate']['dayTotal']
+        const energy_current_netto = (callback[0].aggregate.po); // Netto power usage from aggregated value, this value can go negative
 
-					// Consumed elec current
-					promises.push(me.setCapabilityValue('measure_power.used', energy_current_cons).catch(me.error));
-					// Consumed elec current
-					promises.push(me.setCapabilityValue('measure_power', energy_current_netto).catch(me.error));
-					// Consumed elec current Netto
-					promises.push(me.setCapabilityValue('measure_power.netto', energy_current_netto).catch(me.error));
-					// Consumed elec total day
-					promises.push(me.setCapabilityValue('meter_power.used', energy_daytotal_cons).catch(me.error));
-					// Consumed elec total day
+        // Some Energylink do not have gas information so try to get it else fail silently
+        try {
+          const gas_daytotal_cons = (callback[0].gas.dayTotal); // m3 Energy produced via S1 $energylink[0]['gas']['dayTotal']
+          // Consumed gas
+          await me.setCapabilityValue('meter_gas.today', gas_daytotal_cons).catch(me.error);
+        }
+        catch (err) {
+          // Error with Energylink no data in Energylink
+          console.log('No Gas information found');
+        }
+
+        // Consumed elec current
+        promises.push(me.setCapabilityValue('measure_power.used', energy_current_cons).catch(me.error));
+        // Consumed elec current
+        promises.push(me.setCapabilityValue('measure_power', energy_current_netto).catch(me.error));
+        // Consumed elec current Netto
+        promises.push(me.setCapabilityValue('measure_power.netto', energy_current_netto).catch(me.error));
+        // Consumed elec total day
+        promises.push(me.setCapabilityValue('meter_power.used', energy_daytotal_cons).catch(me.error));
+        // Consumed elec total day
 				    promises.push(me.setCapabilityValue('meter_power.aggr', energy_daytotal_aggr).catch(me.error));
 
-
          			 // Disable meter_power
-					// me.removeCapability('meter_power');
-					// Set solar used to zero before counting
-					let solar_current_prod = 0;
-					let solar_daytotal_prod = 0;
-					let energy_current_prod = 0;
-					let energy_daytotal_prod = 0;
-					let water_current_cons = 0;
-					let water_daytotal_cons = 0;
+        // me.removeCapability('meter_power');
+        // Set solar used to zero before counting
+        let solar_current_prod = 0;
+        let solar_daytotal_prod = 0;
+        let energy_current_prod = 0;
+        let energy_daytotal_prod = 0;
+        let water_current_cons = 0;
+        let water_daytotal_cons = 0;
 
+        if (value_s1 == 'solar') {
+          energy_current_prod = (callback[0].s1.po); // WATTS Energy produced via S1 $energylink[0]['s1']['po']
+          energy_daytotal_prod = (callback[0].s1.dayTotal); // KWH Energy produced via S1 $energylink[0]['s1']['po']
 
-					if (value_s1 == 'solar' ) {
-						energy_current_prod = ( callback[0].s1.po ); // WATTS Energy produced via S1 $energylink[0]['s1']['po']
-						energy_daytotal_prod = ( callback[0].s1.dayTotal ); // KWH Energy produced via S1 $energylink[0]['s1']['po']
+          solar_current_prod += energy_current_prod;
+          solar_daytotal_prod += energy_daytotal_prod;
 
-						solar_current_prod = solar_current_prod + energy_current_prod;
-						solar_daytotal_prod = solar_daytotal_prod + energy_daytotal_prod;
+          if (me.hasCapability('meter_power.s1other')) {
+            promises.push(me.removeCapability('meter_power.s1other').catch(me.error));
+            promises.push(me.removeCapability('measure_power.s1other').catch(me.error));
+          }
+        }
 
-						if (me.hasCapability('meter_power.s1other')) {
-							promises.push(me.removeCapability('meter_power.s1other').catch(me.error));
-							promises.push(me.removeCapability('measure_power.s1other').catch(me.error));
-						}
-					}
+        if (value_s1 == 'solar' || value_s2 == 'solar') {
+          promises.push(me.setCapabilityValue('measure_power.s1', solar_current_prod).catch(me.error));
+          promises.push(me.setCapabilityValue('meter_power.s1', solar_daytotal_prod).catch(me.error));
+          if (me.hasCapability('meter_power.s1other')) {
+            promises.push(me.removeCapability('meter_power.s1other').catch(me.error));
+            promises.push(me.removeCapability('measure_power.s1other').catch(me.error));
+          }
+        }
 
-					if(value_s1 == 'solar' || value_s2 == 'solar') {
-						promises.push(me.setCapabilityValue("measure_power.s1", solar_current_prod ).catch(me.error));
-						promises.push(me.setCapabilityValue("meter_power.s1", solar_daytotal_prod ).catch(me.error));
-						if (me.hasCapability('meter_power.s1other')) {
-							promises.push(me.removeCapability('meter_power.s1other').catch(me.error));
-							promises.push(me.removeCapability('measure_power.s1other').catch(me.error));
-						}
-					}
+        if (value_s2 == 'solar') {
+          energy_current_prod = (callback[0].s2.po); // WATTS Energy produced via S1 $energylink[0]['s2']['po']
+          energy_daytotal_prod = (callback[0].s2.dayTotal); // KWH Energy produced via S1 $energylink[0]['s2']['dayTotal']
 
-					if (value_s2 == 'solar' ) {
-						energy_current_prod = ( callback[0].s2.po ); // WATTS Energy produced via S1 $energylink[0]['s2']['po']
-						energy_daytotal_prod = ( callback[0].s2.dayTotal ); // KWH Energy produced via S1 $energylink[0]['s2']['dayTotal']
+          if (!me.hasCapability('measure_power.s2')) {
+            me.addCapability('measure_power.s2').catch(me.error);
+            me.addCapability('meter_power.s2').catch(me.error);
+          }
+          else {
+            promises.push(me.setCapabilityValue('measure_power.s2', callback[0].s2.po).catch(me.error));
+            promises.push(me.setCapabilityValue('meter_power.s2', callback[0].s2.dayTotal).catch(me.error));
+          }
 
-						if (!me.hasCapability('measure_power.s2')) {
-							me.addCapability('measure_power.s2').catch(me.error);
-							me.addCapability('meter_power.s2').catch(me.error);
-						}
-						else {
-							promises.push(me.setCapabilityValue('measure_power.s2', callback[0].s2.po ).catch(me.error));
-							promises.push(me.setCapabilityValue('meter_power.s2', callback[0].s2.dayTotal ).catch(me.error));
-						}
+          solar_current_prod += energy_current_prod;
+          solar_daytotal_prod += energy_daytotal_prod;
+          if (me.hasCapability('meter_power.s2other')) {
+            promises.push(me.removeCapability('meter_power.s2other').catch(me.error));
+            promises.push(me.removeCapability('measure_power.s2other').catch(me.error));
+          }
+        }
 
-						solar_current_prod = solar_current_prod + energy_current_prod;
-						solar_daytotal_prod = solar_daytotal_prod + energy_daytotal_prod;
-						if (me.hasCapability('meter_power.s2other')) {
-							promises.push(me.removeCapability('meter_power.s2other').catch(me.error));
-							promises.push(me.removeCapability('measure_power.s2other').catch(me.error));
-						}
-					}
+        if (value_s1 == 'water') {
+          water_current_cons = (callback[0].s1.po); // Water used via S1 $energylink[0]['s1']['po']
+          water_daytotal_cons = (callback[0].s1.dayTotal / 1000); // Water used via S1 $energylink[0]['s1']['dayTotal']
+          // console.log("Water- " + water_daytotal_cons);
+          // Used water m3
+          promises.push(me.setCapabilityValue('meter_water', water_daytotal_cons).catch(me.error));
+          promises.push(me.setCapabilityValue('measure_water', water_current_cons).catch(me.error));
 
-					if (value_s1 == 'water' ) {
-						water_current_cons = ( callback[0].s1.po ); // Water used via S1 $energylink[0]['s1']['po']
-						water_daytotal_cons = ( callback[0].s1.dayTotal / 1000 ); // Water used via S1 $energylink[0]['s1']['dayTotal']
-						//console.log("Water- " + water_daytotal_cons);
-						// Used water m3
-						promises.push(me.setCapabilityValue("meter_water", water_daytotal_cons).catch(me.error));
-						promises.push(me.setCapabilityValue("measure_water", water_current_cons).catch(me.error));
+          if (me.hasCapability('meter_power.s1other')) {
+            promises.push(me.removeCapability('meter_power.s1other').catch(me.error));
+            promises.push(me.removeCapability('measure_power.s1other').catch(me.error));
+          }
+        }
 
-						if (me.hasCapability('meter_power.s1other')) {
-							promises.push(me.removeCapability('meter_power.s1other').catch(me.error));
-							promises.push(me.removeCapability('measure_power.s1other').catch(me.error));
-						}
-					}
+        if (value_s2 == 'water') {
+          water_current_cons = (callback[0].s2.po); // Water used via S2 $energylink[0]['s1']['po']
+          water_daytotal_cons = (callback[0].s2.dayTotal / 1000); // Water used via S1 $energylink[0]['s2']['dayTotal']
+          // console.log("Water- " + water_daytotal_cons);
+          // Used water m3
+          promises.push(me.setCapabilityOptions('meter_water', { decimals: 3 }).catch(me.error));
+          promises.push(me.setCapabilityValue('meter_water', water_daytotal_cons).catch(me.error));
+          promises.push(me.setCapabilityValue('measure_water', water_current_cons).catch(me.error));
+          if (me.hasCapability('meter_power.s2other')) {
+            promises.push(me.removeCapability('meter_power.s2other').catch(me.error));
+            promises.push(me.removeCapability('measure_power.s2other').catch(me.error));
+          }
+        }
 
-					if (value_s2 == 'water' ) {
-						water_current_cons = ( callback[0].s2.po ); // Water used via S2 $energylink[0]['s1']['po']
-						water_daytotal_cons = ( callback[0].s2.dayTotal / 1000 ); // Water used via S1 $energylink[0]['s2']['dayTotal']
-						//console.log("Water- " + water_daytotal_cons);
-						// Used water m3
-						promises.push(me.setCapabilityOptions("meter_water", {"decimals":3}).catch(me.error));
-						promises.push(me.setCapabilityValue("meter_water", water_daytotal_cons).catch(me.error));
-						promises.push(me.setCapabilityValue("measure_water", water_current_cons).catch(me.error));
-						if (me.hasCapability('meter_power.s2other')) {
-							promises.push(me.removeCapability('meter_power.s2other').catch(me.error));
-							promises.push(me.removeCapability('measure_power.s2other').catch(me.error));
-						}
-					}
+        if (value_s1 == 'other' || value_s1 == 'car') {
+          const other_current_cons_s1 = (callback[0].s1.po); // Other used via S1 $energylink[0]['s1']['po']
+          const other_daytotal_cons_s1 = (callback[0].s1.dayTotal); // Other used via S1 $energylink[0]['s1']['dayTotal']
+          // console.log("Other- " + other_daytotal_cons_s1);
+          // Used power
+          promises.push(me.setCapabilityValue('meter_power.s1other', other_daytotal_cons_s1).catch(me.error));
+          promises.push(me.setCapabilityValue('measure_power.s1other', other_current_cons_s1).catch(me.error));
+        }
 
-					if (value_s1 == 'other' || value_s1 == 'car') {
-						let other_current_cons_s1 = ( callback[0].s1.po ); // Other used via S1 $energylink[0]['s1']['po']
-						let other_daytotal_cons_s1 = ( callback[0].s1.dayTotal ); // Other used via S1 $energylink[0]['s1']['dayTotal']
-						//console.log("Other- " + other_daytotal_cons_s1);
-						// Used power
-						promises.push(me.setCapabilityValue("meter_power.s1other", other_daytotal_cons_s1).catch(me.error));
-						promises.push(me.setCapabilityValue("measure_power.s1other", other_current_cons_s1).catch(me.error));
-					}
+        if (value_s2 == 'other' || value_s2 == 'car') {
+          const other_current_cons_s2 = (callback[0].s2.po); // Other used via S2 $energylink[0]['s1']['po']
+          const other_daytotal_cons_s2 = (callback[0].s2.dayTotal); // Other used via S1 $energylink[0]['s2']['dayTotal']
+          // console.log("Other- " + other_daytotal_cons_s2);
+          // Used power
+          promises.push(me.setCapabilityValue('meter_power.s2other', other_daytotal_cons_s2).catch(me.error));
+          promises.push(me.setCapabilityValue('measure_power.s2other', other_current_cons_s2).catch(me.error));
+        }
 
-					if (value_s2 == 'other' || value_s2 == 'car' ) {
-						let other_current_cons_s2 = ( callback[0].s2.po ); // Other used via S2 $energylink[0]['s1']['po']
-						let other_daytotal_cons_s2 = ( callback[0].s2.dayTotal ); // Other used via S1 $energylink[0]['s2']['dayTotal']
-						//console.log("Other- " + other_daytotal_cons_s2);
-						// Used power
-						promises.push(me.setCapabilityValue("meter_power.s2other", other_daytotal_cons_s2).catch(me.error));
-						promises.push(me.setCapabilityValue("measure_power.s2other", other_current_cons_s2).catch(me.error));
-					}
+        // Trigger flows
+        if (energy_current_cons != me.getStoreValue('last_measure_power_used') && energy_current_cons != undefined && energy_current_cons != null) {
+          // console.log("Current Power - "+ energy_current_cons);
+          promises.push(me.flowTriggerPowerUsed(me, { power_used: energy_current_cons }));
+          me.setStoreValue('last_measure_power_used', energy_current_cons);
+        }
+        if (energy_current_netto != me.getStoreValue('last_measure_power_netto') && energy_current_netto != undefined && energy_current_netto != null) {
+					    // console.log("Current Netto Power - "+ energy_current_netto);
+          promises.push(me.flowTriggerPowerNetto(me, { netto_power_used: energy_current_netto }));
+          me.setStoreValue('last_measure_power_netto', energy_current_netto);
+        }
 
-					// Trigger flows
-					if (energy_current_cons != me.getStoreValue("last_measure_power_used") && energy_current_cons != undefined && energy_current_cons != null) {
-						//console.log("Current Power - "+ energy_current_cons);
-						promises.push(me.flowTriggerPowerUsed(me, { power_used: energy_current_cons }));
-						me.setStoreValue("last_measure_power_used",energy_current_cons);
-					}
-					if (energy_current_netto != me.getStoreValue('last_measure_power_netto') && energy_current_netto != undefined && energy_current_netto != null) {
-					    //console.log("Current Netto Power - "+ energy_current_netto);
-						promises.push(me.flowTriggerPowerNetto(me, { netto_power_used: energy_current_netto }));
-						me.setStoreValue("last_measure_power_netto",energy_current_netto);
-					}
+        if (value_s1 != 'other' || value_s1 != 'car') {
+          if (energy_current_prod != me.getStoreValue('last_measure_power_s1') && energy_current_prod != undefined && energy_current_prod != null) {
+					        // console.log("Current S1 Solar- "+ solar_current_prod);
+            promises.push(me.flowTriggerPowerS1(me, { power_s1: solar_current_prod }));
+            me.setStoreValue('last_measure_power_s1', solar_current_prod);
 
-					if (value_s1 != 'other' || value_s1 != 'car') {
-						if (energy_current_prod != me.getStoreValue('last_measure_power_s1') && energy_current_prod != undefined && energy_current_prod != null) {
-					        //console.log("Current S1 Solar- "+ solar_current_prod);
-						promises.push(me.flowTriggerPowerS1(me, { power_s1: solar_current_prod }));
-						me.setStoreValue("last_measure_power_s1",solar_current_prod);
+          }
+        }
+        if (value_s1 == 'other' || value_s1 == 'car') {
+          const other_current_cons_s1 = (callback[0].s1.po); // Other used via S1 $energylink[0]['s1']['po']
+          if (other_current_cons_s1 != me.getStoreValue('last_measure_power_s1') && other_current_cons_s1 != undefined && other_current_cons_s1 != null) {
+            // console.log("Current S1 - "+ other_current_cons_s1);
+            promises.push(me.flowTriggerPowerS1(me, { power_s1: other_current_cons_s1 }));
+            me.setStoreValue('last_measure_power_s1', other_current_cons_s1);
 
-						}
-					}
-					if (value_s1 == 'other' || value_s1 == 'car') {
-						let other_current_cons_s1 = ( callback[0].s1.po ); // Other used via S1 $energylink[0]['s1']['po']
-						if (other_current_cons_s1 != me.getStoreValue('last_measure_power_s1') && other_current_cons_s1 != undefined && other_current_cons_s1 != null) {
-									//console.log("Current S1 - "+ other_current_cons_s1);
-						promises.push(me.flowTriggerPowerS1(me, { power_s1: other_current_cons_s1 }));
-						me.setStoreValue("last_measure_power_s1",other_current_cons_s1);
+          }
+        }
 
-						}
-					}
+        if (value_s2 == 'other' || value_s2 == 'car') {
+          const other_current_cons_s2 = (callback[0].s2.po); // Other used via S2 $energylink[0]['s1']['po']
+          if (other_current_cons_s2 != me.getStoreValue('last_measure_power_s2') && other_current_cons_s2 != undefined && other_current_cons_s2 != null) {
+            // console.log("Current S2 - "+ other_current_cons_s2);
+            promises.push(me.flowTriggerPowerS2(me, { power_s2: other_current_cons_s2 }));
+            me.setStoreValue('last_measure_power_s2', other_current_cons_s2);
 
-					if (value_s2 == 'other' || value_s2 == 'car') {
-						let other_current_cons_s2 = ( callback[0].s2.po ); // Other used via S2 $energylink[0]['s1']['po']
-						if (other_current_cons_s2 != me.getStoreValue('last_measure_power_s2') && other_current_cons_s2 != undefined && other_current_cons_s2 != null) {
-									//console.log("Current S2 - "+ other_current_cons_s2);
-						promises.push(me.flowTriggerPowerS2(me, { power_s2: other_current_cons_s2 }));
-						me.setStoreValue("last_measure_power_s2",other_current_cons_s2);
+          }
+        }
 
-						}
-					}
-
-
-					if (energy_daytotal_cons != me.getStoreValue('last_meter_power_used') && energy_daytotal_cons != undefined && energy_daytotal_cons != null) {
-					    //console.log("Used Daytotal- "+ energy_daytotal_cons);
-						promises.push(me.flowTriggerMeterPowerUsed(me, { power_daytotal_used: energy_current_prod }));
-						me.setStoreValue("last_meter_power_used",energy_daytotal_cons);
-					}
+        if (energy_daytotal_cons != me.getStoreValue('last_meter_power_used') && energy_daytotal_cons != undefined && energy_daytotal_cons != null) {
+					    // console.log("Used Daytotal- "+ energy_daytotal_cons);
+          promises.push(me.flowTriggerMeterPowerUsed(me, { power_daytotal_used: energy_current_prod }));
+          me.setStoreValue('last_meter_power_used', energy_daytotal_cons);
+        }
 
           			if (value_s1 != 'other' || value_s1 != 'car') {
-						if (energy_daytotal_prod != me.getStoreValue('last_meter_power_s1') && energy_daytotal_prod != undefined && energy_daytotal_prod != null) {
-					    	//console.log("S1 Daytotal Solar- "+ solar_daytotal_prod);
-							promises.push(me.flowTriggerMeterPowerS1(me, { power_daytotal_s1: solar_daytotal_prod }));
-								me.setStoreValue("last_meter_power_s1",solar_daytotal_prod);
-								}
-					}
+          if (energy_daytotal_prod != me.getStoreValue('last_meter_power_s1') && energy_daytotal_prod != undefined && energy_daytotal_prod != null) {
+					    	// console.log("S1 Daytotal Solar- "+ solar_daytotal_prod);
+            promises.push(me.flowTriggerMeterPowerS1(me, { power_daytotal_s1: solar_daytotal_prod }));
+            me.setStoreValue('last_meter_power_s1', solar_daytotal_prod);
+          }
+        }
 
-					if (value_s1 == 'other' || value_s1 == 'car') {
-						let other_daytotal_cons_s1 = ( callback[0].s1.dayTotal ); // Other used via S1 $energylink[0]['s1']['dayTotal']
-						if (other_daytotal_cons_s1 != me.getStoreValue('last_meter_power_s1') && other_daytotal_cons_s1 != undefined && other_daytotal_cons_s1 != null) {
-					    	//console.log("S1 Daytotal- "+ other_daytotal_cons_s1);
-							promises.push(me.flowTriggerMeterPowerS1(me, { power_daytotal_s1: other_daytotal_cons_s1 }));
-								me.setStoreValue("last_meter_power_s1",other_daytotal_cons_s1);
-								}
-					}
+        if (value_s1 == 'other' || value_s1 == 'car') {
+          const other_daytotal_cons_s1 = (callback[0].s1.dayTotal); // Other used via S1 $energylink[0]['s1']['dayTotal']
+          if (other_daytotal_cons_s1 != me.getStoreValue('last_meter_power_s1') && other_daytotal_cons_s1 != undefined && other_daytotal_cons_s1 != null) {
+					    	// console.log("S1 Daytotal- "+ other_daytotal_cons_s1);
+            promises.push(me.flowTriggerMeterPowerS1(me, { power_daytotal_s1: other_daytotal_cons_s1 }));
+            me.setStoreValue('last_meter_power_s1', other_daytotal_cons_s1);
+          }
+        }
 
-					if (value_s2 == 'other' || value_s2 == 'car') {
-						let other_daytotal_cons_s2 = ( callback[0].s2.dayTotal ); // Other used via S1 $energylink[0]['s2']['dayTotal']
-						if (other_daytotal_cons_s2 != me.getStoreValue('last_meter_power_s2') && other_daytotal_cons_s2 != undefined && other_daytotal_cons_s2 != null) {
-					    	//console.log("S2 Daytotal- "+ other_daytotal_cons_s2);
-							promises.push(me.flowTriggerMeterPowerS2(me, { power_daytotal_s2: other_daytotal_cons_s2 }));
-								me.setStoreValue("last_meter_power_s2",other_daytotal_cons_s2);
-								}
-					}
+        if (value_s2 == 'other' || value_s2 == 'car') {
+          const other_daytotal_cons_s2 = (callback[0].s2.dayTotal); // Other used via S1 $energylink[0]['s2']['dayTotal']
+          if (other_daytotal_cons_s2 != me.getStoreValue('last_meter_power_s2') && other_daytotal_cons_s2 != undefined && other_daytotal_cons_s2 != null) {
+					    	// console.log("S2 Daytotal- "+ other_daytotal_cons_s2);
+            promises.push(me.flowTriggerMeterPowerS2(me, { power_daytotal_s2: other_daytotal_cons_s2 }));
+            me.setStoreValue('last_meter_power_s2', other_daytotal_cons_s2);
+          }
+        }
 
-					if (energy_daytotal_aggr != me.getStoreValue('last_meter_power_aggr') && energy_daytotal_aggr != undefined && energy_daytotal_aggr != null) {
-					    //console.log("Aggregated Daytotal- "+ energy_daytotal_aggr);
-						promises.push(me.flowTriggerMeterPowerAggregated(me, { power_daytotal_aggr: energy_daytotal_aggr }));
-						me.setStoreValue("last_meter_power_aggr",energy_daytotal_aggr);
+        if (energy_daytotal_aggr != me.getStoreValue('last_meter_power_aggr') && energy_daytotal_aggr != undefined && energy_daytotal_aggr != null) {
+					    // console.log("Aggregated Daytotal- "+ energy_daytotal_aggr);
+          promises.push(me.flowTriggerMeterPowerAggregated(me, { power_daytotal_aggr: energy_daytotal_aggr }));
+          me.setStoreValue('last_meter_power_aggr', energy_daytotal_aggr);
 
-					}
-					// Execute all promises concurrently using Promise.all()
-					await Promise.all(promises);
+        }
+        // Execute all promises concurrently using Promise.all()
+        await Promise.all(promises);
 
-				} else {
-					this.setUnavailable('No Energylink data available');
-				}
+      } else {
+        this.setUnavailable('No Energylink data available');
+      }
 
-				} catch (error) {
-					console.log(error);
-					me.setUnavailable();
-				}
-	}
-		
+    } catch (error) {
+      console.log(error);
+      me.setUnavailable();
+    }
+  }
 
+  async getReadings() {
+    const homewizard_id = this.getSetting('homewizard_id');
 
-	async getReadings() {
-		const homewizard_id = this.getSetting('homewizard_id');
-			  
-		try {
+    try {
 		  const callback = await homewizard.getDeviceData(homewizard_id, 'energylink_el');
-		  	  
+
 		  if (Object.keys(callback).length > 0) {
-			this.setAvailable().catch(this.error);
+        this.setAvailable().catch(this.error);
 
-			 
-			let metered_gas = callback[2].consumed;
-			let metered_electricity_consumed_t1 = callback[0].consumed;
-			let metered_electricity_produced_t1 = callback[0].produced;
-			let metered_electricity_consumed_t2 = callback[1].consumed;
-			let metered_electricity_produced_t2 = callback[1].produced;
+        const metered_gas = callback[2].consumed;
+        const metered_electricity_consumed_t1 = callback[0].consumed;
+        const metered_electricity_produced_t1 = callback[0].produced;
+        const metered_electricity_consumed_t2 = callback[1].consumed;
+        let metered_electricity_produced_t2 = callback[1].produced;
 
-			if (metered_electricity_produced_t2 < 0) {metered_electricity_produced_t2 = metered_electricity_produced_t2 * -1};
+        if (metered_electricity_produced_t2 < 0) { metered_electricity_produced_t2 *= -1; }
 
-			let aggregated_meter_power = (metered_electricity_consumed_t1 + metered_electricity_consumed_t2) - (metered_electricity_produced_t1 + metered_electricity_produced_t2);
-	  
-			if (!this.hasCapability('meter_power')) {
+        const aggregated_meter_power = (metered_electricity_consumed_t1 + metered_electricity_consumed_t2) - (metered_electricity_produced_t1 + metered_electricity_produced_t2);
+
+        if (!this.hasCapability('meter_power')) {
 			  await this.addCapability('meter_power').catch(this.error);
-			}
-	  
-			this.setCapabilityValue('meter_gas.reading', metered_gas).catch(this.error);
-			this.setCapabilityValue('meter_power', aggregated_meter_power).catch(this.error);
-			this.setCapabilityValue('meter_power.consumed.t1', metered_electricity_consumed_t1).catch(this.error);
-			this.setCapabilityValue('meter_power.produced.t1', metered_electricity_produced_t1).catch(this.error);
-			this.setCapabilityValue('meter_power.consumed.t2', metered_electricity_consumed_t2).catch(this.error);
-			this.setCapabilityValue('meter_power.produced.t2', metered_electricity_produced_t2).catch(this.error);
-	  
-			if (metered_electricity_produced_t1 != this.getStoreValue('last_meter_return_t1') && metered_electricity_produced_t1 != undefined && metered_electricity_produced_t1 != null) {
+        }
+
+        this.setCapabilityValue('meter_gas.reading', metered_gas).catch(this.error);
+        this.setCapabilityValue('meter_power', aggregated_meter_power).catch(this.error);
+        this.setCapabilityValue('meter_power.consumed.t1', metered_electricity_consumed_t1).catch(this.error);
+        this.setCapabilityValue('meter_power.produced.t1', metered_electricity_produced_t1).catch(this.error);
+        this.setCapabilityValue('meter_power.consumed.t2', metered_electricity_consumed_t2).catch(this.error);
+        this.setCapabilityValue('meter_power.produced.t2', metered_electricity_produced_t2).catch(this.error);
+
+        if (metered_electricity_produced_t1 != this.getStoreValue('last_meter_return_t1') && metered_electricity_produced_t1 != undefined && metered_electricity_produced_t1 != null) {
 			  this.flowTriggerMeterReturnT1(this, { meter_power_produced_t1: metered_electricity_produced_t1 });
 			  this.setStoreValue('last_meter_return_t1', metered_electricity_produced_t1);
-			}
-	  
-			if (metered_electricity_produced_t2 != this.getStoreValue('last_meter_return_t2') && metered_electricity_produced_t2 != undefined && metered_electricity_produced_t2 != null) {
+        }
+
+        if (metered_electricity_produced_t2 != this.getStoreValue('last_meter_return_t2') && metered_electricity_produced_t2 != undefined && metered_electricity_produced_t2 != null) {
 			  this.flowTriggerMeterReturnT2(this, { meter_power_produced_t2: metered_electricity_produced_t2 });
 			  this.setStoreValue('last_meter_return_t2', metered_electricity_produced_t2);
-			}
-			
+        }
 
 		  }
-		} catch (err) {
+    } catch (err) {
 		  console.log('ERROR Energylink getStatus ', err);
 		  this.setUnavailable().catch(this.error);
-		}
+    }
 	  }
-	  
 
-	onDeleted() {
+  onDeleted() {
 
-		clearInterval(this.refreshIntervalId);
-		clearInterval(this.refreshIntervalIdReadings);
-		console.log("--Stopped Polling--");
-		console.log('deleted: ' + JSON.stringify(this));
+    clearInterval(this.refreshIntervalId);
+    clearInterval(this.refreshIntervalIdReadings);
+    console.log('--Stopped Polling--');
+    console.log(`deleted: ${JSON.stringify(this)}`);
 
-	}
+  }
 
 }
 

--- a/drivers/energylink/driver.js
+++ b/drivers/energylink/driver.js
@@ -2,93 +2,94 @@
 
 const Homey = require('homey');
 
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('homewizard');
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('homewizard');
 
-var homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
-var devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let homewizard_devices;
+const devices = {};
 
 class HomeWizardEnergyLink extends Homey.Driver {
 
-    onInit() {
-        console.log('HomeWizard EnergyLink has been inited');
-    }
+  onInit() {
+    console.log('HomeWizard EnergyLink has been inited');
+  }
 
-    async onPair(socket) {
-        // Show a specific view by ID
-        await socket.showView('start');
+  async onPair(socket) {
+    // Show a specific view by ID
+    await socket.showView('start');
 
-        // Show the next view
-        await socket.nextView();
+    // Show the next view
+    await socket.nextView();
 
-        // Show the previous view
-        await socket.prevView();
+    // Show the previous view
+    await socket.prevView();
 
-        // Close the pair session
-        await socket.done();
+    // Close the pair session
+    await socket.done();
 
-        // Received when a view has changed
-        socket.setHandler('showView', function (viewId) {
-          console.log('View: ' + viewId);
-          //this.log("data", viewId);
+    // Received when a view has changed
+    socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      // this.log("data", viewId);
+    });
+
+    // socket.on('get_homewizards', function () {
+
+    socket.setHandler('get_homewizards', () => {
+      homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+
+      // homewizard_devices = driver.getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          const energylinks = JSON.stringify(homewizard_devices[key].polldata.energylinks);
+
+          hw_devices[key] = homewizard_devices[key];
+          hw_devices[key].id = key;
+          hw_devices[key].polldata = {};
+          hw_devices[key].energylinks = energylinks;
+
         });
 
-        //socket.on('get_homewizards', function () {
+        socket.emit('hw_devices', hw_devices);
 
-        socket.setHandler('get_homewizards', () => {
-              homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+      });
+    });
 
-            //homewizard_devices = driver.getDevices();
+    socket.setHandler('manual_add', (device) => {
 
-            homewizard.getDevices(function ( homewizard_devices)  {
-                var hw_devices = {};
+      console.log(device.settings.homewizard_id);
+      console.log(device.settings.homewizard_id.indexOf('HW_'));
 
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    var energylinks = JSON.stringify(homewizard_devices[key].polldata.energylinks);
+      console.log(device.settings.homewizard_id);
+      console.log(device.settings.homewizard_id.indexOf('HW'));
 
-                    hw_devices[key] = homewizard_devices[key];
-                    hw_devices[key].id = key;
-                    hw_devices[key].polldata = {}
-                    hw_devices[key].energylinks = energylinks;
+      if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`Energylink added ${device.data.id}`);
 
-                });
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: 'EnergyLink',
+          settings: device.settings,
+        };
+        // callback( null, devices );
+        socket.emit('success', device);
+        return devices;
 
-                socket.emit('hw_devices', hw_devices);
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
 
-            });
-        });
+    });
 
-        socket.setHandler('manual_add', function (device) {
-
-            console.log(device.settings.homewizard_id);
-            console.log(device.settings.homewizard_id.indexOf('HW_'));
-
-            console.log(device.settings.homewizard_id);
-            console.log(device.settings.homewizard_id.indexOf('HW'));
-
-            if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('Energylink added ' + device.data.id);
-
-                devices[device.data.id] = {
-                    id: device.data.id,
-                    name: "EnergyLink",
-                    settings: device.settings,
-                };
-                //callback( null, devices );
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
-            }
-        });
-
-        socket.setHandler('disconnect', function() {
-            console.log("User aborted pairing, or pairing is finished");
-        });
-    }
+    socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+  }
 
 }
 

--- a/drivers/heatlink/device.js
+++ b/drivers/heatlink/device.js
@@ -1,208 +1,193 @@
 'use strict';
 
 const Homey = require('homey');
-var homewizard = require('./../../includes/homewizard.js');
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('heatlink');
+const homewizard = require('../../includes/homewizard.js');
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('heatlink');
 
-var refreshIntervalId;
-var devices = {};
-//var temperature;
+let refreshIntervalId;
+const devices = {};
+// var temperature;
 
-var debug = false;
+const debug = false;
 
 class HomeWizardHeatlink extends Homey.Device {
 
-	onInit() {
+  onInit() {
 
-		console.log('HomeWizard Heatlink '+this.getName() +' has been inited');
+    console.log(`HomeWizard Heatlink ${this.getName()} has been inited`);
 
+    const devices = this.homey.drivers.getDriver('heatlink').getDevices(); // or heatlink
+    devices.forEach((device) => {
+      console.log(`add device: ${JSON.stringify(device.getName())}`);
 
-		const devices = this.homey.drivers.getDriver('heatlink').getDevices(); // or heatlink
-		devices.forEach(function initdevice(device) {
-			console.log('add device: ' + JSON.stringify(device.getName()));
+      devices[device.getData().id] = device;
+      devices[device.getData().id].settings = device.getSettings();
+    });
 
-			devices[device.getData().id] = device;
-			devices[device.getData().id].settings = device.getSettings();
-		});
+    this.startPolling();
 
-		this.startPolling();
+    this.registerCapabilityListener('target_temperature', (temperature) => {
+      // Catch faulty trigger and max/min temp
+      if (!temperature) {
+        // callback(true, temperature);
+        return false;
+      }
+      if (temperature < 5) {
+        temperature = 5;
+      }
+      else if (temperature > 35) {
+        temperature = 35;
+      }
+      temperature = Math.round(temperature.toFixed(1) * 2) / 2;
 
-		this.registerCapabilityListener('target_temperature', ( temperature) => {
-			// Catch faulty trigger and max/min temp
-			if (!temperature) {
-				//callback(true, temperature);
-				return false;
-			}
-			else if (temperature < 5) {
-				temperature = 5;
-			}
-			else if (temperature > 35) {
-				temperature = 35;
-			}
-			temperature = Math.round(temperature.toFixed(1) * 2) / 2;
+      return new Promise(async (resolve) => { // async
+        const url = `/hl/0/settarget/${temperature}`;
+        console.log(url); // Console log url
+        const homewizard_id = this.getSetting('homewizard_id');
+			    	await homewizard.callnew(homewizard_id, `/hl/0/settarget/${temperature}`, (err) => { // await, maybe a timestamp for log?
+          if (err) {
+            // console.log('ERR settarget target_temperature -> returned false');
+            console.log('ERR settarget target_temperature -> returned false');
+            return resolve(false);
+          }
+          // console.log('settarget target_temperature - returned true');
+          console.log('settarget target_temperature - returned true');
+          return resolve(true);
+        });
+      });
+      // return Promise.resolve(); eslint?
+    });
+  }
 
-			return new Promise(async (resolve) => { //async 
-					var url = '/hl/0/settarget/'+temperature;
-					console.log(url); // Console log url
-					var homewizard_id = this.getSetting('homewizard_id');
-			    	await homewizard.callnew(homewizard_id, '/hl/0/settarget/'+temperature, function(err) { //await, maybe a timestamp for log?
-						if (err) {
-							//console.log('ERR settarget target_temperature -> returned false');
-							console.log ('ERR settarget target_temperature -> returned false');
-							return resolve(false);
-						}
-						//console.log('settarget target_temperature - returned true');
-						console.log('settarget target_temperature - returned true');
-						return resolve(true);
-				});
-			});
-			//return Promise.resolve(); eslint?
-		});
-	}
+  startPolling() {
 
-	startPolling() {
+    // Clear interval
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
 
-		// Clear interval
-		if (this.refreshIntervalId) {
-			clearInterval(this.refreshIntervalId);
-		}
+    // Start polling for thermometer
+    this.refreshIntervalId = setInterval(() => {
+      if (debug) { console.log('--Start Heatlink Polling-- '); }
 
-		// Start polling for thermometer
-		this.refreshIntervalId = setInterval(() => {
-			if (debug) {console.log("--Start Heatlink Polling-- ");}
+      this.getStatus();
 
-			this.getStatus();
+    }, 1000 * 20);
 
-		}, 1000 * 20 );
+  }
 
-	}
-
-	async getStatus() {
-		if (this.getSetting('homewizard_id') !== undefined) {
+  async getStatus() {
+    if (this.getSetting('homewizard_id') !== undefined) {
 		  const homewizard_id = this.getSetting('homewizard_id');
-	
+
 		  try {
-			const callback = await homewizard.getDeviceData(homewizard_id, 'heatlinks');
-	
-			if (Object.keys(callback).length > 0) {
+        const callback = await homewizard.getDeviceData(homewizard_id, 'heatlinks');
+
+        if (Object.keys(callback).length > 0) {
 			  this.setAvailable().catch(this.error);
 
 			  const promises = []; // Capture all await promises
-	
+
 			  const rte = (callback[0].rte.toFixed(1) * 2) / 2;
 			  const rsp = (callback[0].rsp.toFixed(1) * 2) / 2;
 			  const tte = (callback[0].tte.toFixed(1) * 2) / 2;
 			  const wte = (callback[0].wte.toFixed(1) * 2) / 2;
-	
+
 			  if (this.getStoreValue('temperature') != rte) {
-				if (debug) {console.log('New RTE - ' + rte);}
-				promises.push(this.setCapabilityValue('measure_temperature', rte).catch(this.error));
-				this.setStoreValue('temperature', rte).catch(this.error);
-			  } else {
-				if (debug) {console.log('RTE: no change');}
-			  }
-	
+            if (debug) { console.log(`New RTE - ${rte}`); }
+            promises.push(this.setCapabilityValue('measure_temperature', rte).catch(this.error));
+            this.setStoreValue('temperature', rte).catch(this.error);
+			  } else if (debug) { console.log('RTE: no change'); }
+
 			  if (this.getStoreValue('thermTemperature') != rsp) {
-				if (debug){console.log('New RSP - ' + rsp);}
-				if (this.getStoreValue('setTemperature') === 0) {
-					promises.push(this.setCapabilityValue('target_temperature', rsp).catch(this.error));
-				}
-				this.setStoreValue('thermTemperature', rsp).catch(this.error);
-			  } else {
-				if (debug){console.log('RSP: no change');}
-			  }
-	
+            if (debug) { console.log(`New RSP - ${rsp}`); }
+            if (this.getStoreValue('setTemperature') === 0) {
+              promises.push(this.setCapabilityValue('target_temperature', rsp).catch(this.error));
+            }
+            this.setStoreValue('thermTemperature', rsp).catch(this.error);
+			  } else if (debug) { console.log('RSP: no change'); }
+
 			  if (this.getStoreValue('setTemperature') != tte) {
-				if (debug){console.log('New TTE - ' + tte);}
-				if (tte > 0) {
-					promises.push(this.setCapabilityValue('target_temperature', tte).catch(this.error));
-				} else {
-					promises.push(this.setCapabilityValue('target_temperature', this.getStoreValue('thermTemperature')).catch(this.error));
-				}
-				this.setStoreValue('setTemperature', tte).catch(this.error);
-			  } else {
-				if (debug){console.log('TTE: no change');}
-			  }
-	
+            if (debug) { console.log(`New TTE - ${tte}`); }
+            if (tte > 0) {
+              promises.push(this.setCapabilityValue('target_temperature', tte).catch(this.error));
+            } else {
+              promises.push(this.setCapabilityValue('target_temperature', this.getStoreValue('thermTemperature')).catch(this.error));
+            }
+            this.setStoreValue('setTemperature', tte).catch(this.error);
+			  } else if (debug) { console.log('TTE: no change'); }
+
 			  if (!this.hasCapability('measure_temperature.boiler')) {
-				promises.push(this.addCapability('measure_temperature.boiler').catch(this.error));
+            promises.push(this.addCapability('measure_temperature.boiler').catch(this.error));
 			  } else {
-				promises.push(this.setCapabilityValue('measure_temperature.boiler', wte).catch(this.error));
+            promises.push(this.setCapabilityValue('measure_temperature.boiler', wte).catch(this.error));
 			  }
-	
+
 			  if (!this.hasCapability('measure_temperature.heatlink')) {
-				promises.push(this.addCapability('measure_temperature.heatlink').catch(this.error));
+            promises.push(this.addCapability('measure_temperature.heatlink').catch(this.error));
 			  } else {
-				promises.push(this.setCapabilityValue('measure_temperature.heatlink', tte).catch(this.error));
+            promises.push(this.setCapabilityValue('measure_temperature.heatlink', tte).catch(this.error));
 			  }
-	
+
 			  if (!this.hasCapability('central_heating_flame')) {
-				promises.push(this.addCapability('central_heating_flame').catch(this.error));
-			  } else {
-					if (callback[0].heating === 'on') {
-						promises.push(this.setCapabilityValue('central_heating_flame', true).catch(this.error));
-						}
-						else {
-							promises.push(this.setCapabilityValue('central_heating_flame', false).catch(this.error));
-						}
-					}
-	
+            promises.push(this.addCapability('central_heating_flame').catch(this.error));
+			  } else if (callback[0].heating === 'on') {
+            promises.push(this.setCapabilityValue('central_heating_flame', true).catch(this.error));
+          }
+          else {
+            promises.push(this.setCapabilityValue('central_heating_flame', false).catch(this.error));
+          }
+
 			  if (!this.hasCapability('central_heating_pump')) {
-				promises.push(this.addCapability('central_heating_pump').catch(this.error));
-			  } else {
-				if (callback[0].pump === 'on') {
-					promises.push(this.setCapabilityValue('central_heating_pump', true).catch(this.error));
-				}
-					else {
-						promises.push(this.setCapabilityValue('central_heating_pump', false).catch(this.error));
-					}
-			  }
+            promises.push(this.addCapability('central_heating_pump').catch(this.error));
+			  } else if (callback[0].pump === 'on') {
+            promises.push(this.setCapabilityValue('central_heating_pump', true).catch(this.error));
+          }
+          else {
+            promises.push(this.setCapabilityValue('central_heating_pump', false).catch(this.error));
+          }
 
 			  if (!this.hasCapability('warm_water')) {
-				promises.push(this.addCapability('warm_water').catch(this.error));
-			  } else {
-				if (callback[0].dhw === 'on') {
-					promises.push(this.setCapabilityValue('warm_water', true).catch(this.error));
-				}
-					else {
-						promises.push(this.setCapabilityValue('warm_water', false).catch(this.error));
-					}
-			  }
+            promises.push(this.addCapability('warm_water').catch(this.error));
+			  } else if (callback[0].dhw === 'on') {
+            promises.push(this.setCapabilityValue('warm_water', true).catch(this.error));
+          }
+          else {
+            promises.push(this.setCapabilityValue('warm_water', false).catch(this.error));
+          }
 
-	
 			  if (!this.hasCapability('measure_pressure')) {
-				promises.push(this.addCapability('measure_pressure').catch(this.error));
+            promises.push(this.addCapability('measure_pressure').catch(this.error));
 			  } else {
-				promises.push(this.setCapabilityValue('measure_pressure', callback[0].wp).catch(this.error));
+            promises.push(this.setCapabilityValue('measure_pressure', callback[0].wp).catch(this.error));
 			  }
 
-			// Execute all promises concurrently using Promise.all()
-			await Promise.all(promises);
+          // Execute all promises concurrently using Promise.all()
+          await Promise.all(promises);
 
-			}
+        }
 		  } catch (error) {
-			console.log('Heatlink data error', error);
-			this.setUnavailable().catch(this.error);
+        console.log('Heatlink data error', error);
+        this.setUnavailable().catch(this.error);
 		  }
-		} else {
+    } else {
 		  console.log('HW ID not found');
 		  if (Object.keys(devices).length === 1) {
-			clearInterval(this.refreshIntervalId);
+        clearInterval(this.refreshIntervalId);
 		  }
-		}
+    }
 	  }
-	  
 
-onDeleted() {
+  onDeleted() {
 
-		if (Object.keys(devices).length === 0) {
-			clearInterval(refreshIntervalId);
-			console.log("--Stopped Polling--");
-		}
+    if (Object.keys(devices).length === 0) {
+      clearInterval(refreshIntervalId);
+      console.log('--Stopped Polling--');
+    }
 
-		console.log('deleted: ' + JSON.stringify(this));
-	}
+    console.log(`deleted: ${JSON.stringify(this)}`);
+  }
 
 }
 

--- a/drivers/heatlink/driver.js
+++ b/drivers/heatlink/driver.js
@@ -2,105 +2,105 @@
 
 const Homey = require('homey');
 
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('homewizard');
-var devices = {};
-var homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('homewizard');
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let homewizard_devices;
 
 class HomeWizardHeatlink extends Homey.Driver {
 
-
   onInit() {
-        console.log('HomeWizard Heatlink has been inited');
+    console.log('HomeWizard Heatlink has been inited');
 
-        this.homey.flow.getActionCard('heatlink_off')
-            //.register()
-            .registerRunListener((args) => {
-                if (!args.device) {
-                    return false;
-                }
+    this.homey.flow.getActionCard('heatlink_off')
+    // .register()
+      .registerRunListener((args) => {
+        if (!args.device) {
+          return false;
+        }
 
-                return new Promise((resolve) => {
+        return new Promise((resolve) => {
 
-                    homewizard.callnew(args.device.getData().id, '/hl/0/settarget/0', function(err) {
-                        if(err) {
-                            console.log('ERR flowCardAction heatlink_off  -> returned false');
-                            return resolve(false);
-                        }
-
-                        console.log('flowCardAction heatlink_off  -> returned true');
-                        return resolve(true);
-                    });
-
-                });
-            });
-
-    }
-
-    async onPair(socket) {
-
-        // Show a specific view by ID
-        await socket.showView('start');
-
-        // Show the next view
-        await socket.nextView();
-
-        // Show the previous view
-        await socket.prevView();
-
-        // Close the pair session
-        await socket.done();
-
-        // Received when a view has changed
-        await socket.setHandler('showView', function (viewId) {
-            console.log('View: ' + viewId);
-            //this.log("data", viewId);
-        });
-
-        //socket.on('get_homewizards', function () {
-        await socket.setHandler('get_homewizards', () => {
-
-            //homewizard_devices = driver.getDevices();
-            homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
-
-            homewizard.getDevices(function (homewizard_devices)  {
-                var hw_devices = {};
-
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    hw_devices[key] = homewizard_devices[key];
-                });
-
-                console.log(hw_devices);
-                socket.emit('hw_devices', hw_devices);
-
-            });
-        });
-
-        await socket.setHandler('manual_add', function (device) {
-
-            if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('HeatLink added ' + device.data.id);
-                devices[device.data.id] = {
-                  id: device.data.id,
-                  name: device.name,
-                  settings: device.settings,
-                };
-                //callback( null, devices );
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
+          homewizard.callnew(args.device.getData().id, '/hl/0/settarget/0', (err) => {
+            if (err) {
+              console.log('ERR flowCardAction heatlink_off  -> returned false');
+              return resolve(false);
             }
+
+            console.log('flowCardAction heatlink_off  -> returned true');
+            return resolve(true);
+          });
+
+        });
+      });
+
+  }
+
+  async onPair(socket) {
+
+    // Show a specific view by ID
+    await socket.showView('start');
+
+    // Show the next view
+    await socket.nextView();
+
+    // Show the previous view
+    await socket.prevView();
+
+    // Close the pair session
+    await socket.done();
+
+    // Received when a view has changed
+    await socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      // this.log("data", viewId);
+    });
+
+    // socket.on('get_homewizards', function () {
+    await socket.setHandler('get_homewizards', () => {
+
+      // homewizard_devices = driver.getDevices();
+      homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          hw_devices[key] = homewizard_devices[key];
         });
 
-        socket.setHandler('disconnect', function() {
-            console.log("User aborted pairing, or pairing is finished");
-        });
+        console.log(hw_devices);
+        socket.emit('hw_devices', hw_devices);
 
-    }
+      });
+    });
+
+    await socket.setHandler('manual_add', (device) => {
+
+      if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`HeatLink added ${device.data.id}`);
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+        };
+        // callback( null, devices );
+        socket.emit('success', device);
+        return devices;
+
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
+
+    });
+
+    socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+
+  }
 
 }
 

--- a/drivers/homewizard/driver.js
+++ b/drivers/homewizard/driver.js
@@ -1,202 +1,202 @@
 'use strict';
 
 const Homey = require('homey');
-//const request = require('request');
+// const request = require('request');
 const fetch = require('node-fetch');
 
-var devices = {};
-var homewizard = require('./../../includes/homewizard.js');
-var refreshIntervalId;
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let refreshIntervalId;
 
 class HomeWizardDriver extends Homey.Driver {
-    onInit() {
-        console.log('HomeWizard has been inited');
+  onInit() {
+    console.log('HomeWizard has been inited');
 
-        var me = this;
+    const me = this;
 
-        // PRESETS
-         this.homey.flow.getConditionCard('check_preset')
-            //.register()
-            .registerRunListener( async (args, state) => {
-                if (! args.device) {
-                    return false;
-                }
-
-                return new Promise((resolve, reject) => {
-                    homewizard.callnew(args.device.getData().id, '/get-status/', (err, response) => {
-                        if (err) {
-                            console.log('ERR flowCardCondition  -> returned false');
-                            // You can make a choice here: reject the promise with the error,
-                            // or resolve it to return "false" return resolve(false); // OR: return reject(err)
-                        }
-                        //console.log('arg.preset '+ args.preset + ' - hw preset ' +response.preset);
-                        //console.log(' flowCardCondition CheckPreset -> returned', (args.preset == response.preset));
-                        return resolve(args.preset == response.preset);
-                    });
-                });
-            });
-
-        this.homey.flow.getActionCard('set_preset')
-            //.register()
-            .registerRunListener( async (args, state) => {
-                if (! args.device) {
-                    return false;
-                }
-
-                return new Promise((resolve, reject) => {
-
-                    var uri = '/preset/' + args.preset;
-
-                    homewizard.callnew(args.device.getData().id, uri, function(err, response) {
-                        if(err) {
-                            me.log('ERR flowCardAction set_preset  -> returned false');
-                            return resolve(false);
-                        }
-
-                        me.log('flowCardAction set_preset  -> returned true');
-                        return resolve(true);
-
-                    });
-                });
-            });
-
-        // SCENES
-        this.homey.flow.getActionCard('switch_scene_on')
-            //.register()
-            .registerRunListener( async (args, state) => {
-                if (! args.device) {
-                    return false;
-                }
-
-                return new Promise((resolve, reject) => {
-                    homewizard.callnew(args.device.getData().id, '/gp/' + args.scene.id + '/on', function(err, response) {
-                        if(err) {
-                            me.log('ERR flowCardAction switch_scene_on  -> returned false');
-                            return resolve(false);
-                        }
-
-                        me.log('flowCardAction switch_scene_on  -> returned true');
-                        return resolve(true);
-
-                    });
-                });
-            })
-            .getArgument('scene')
-            .registerAutocompleteListener(async (query, args) => {
-                console.log('CALLED flowCardAction switch_scene_on autocomplete');
-
-                return this._onGetSceneAutocomplete(args);
-
-
-            });
-
-        // SCENES
-        this.homey.flow.getActionCard('switch_scene_off')
-            //.register()
-            .registerRunListener( async (args, state) => {
-                if (! args.device) {
-                    return false;
-                }
-
-                return new Promise((resolve, reject) => {
-                    homewizard.callnew(args.device.getData().id, '/gp/' + args.scene.id + '/off', function(err, response) {
-                        if(err) {
-                            console.log('ERR flowCardAction switch_scene_off  -> returned false');
-                            return resolve(false);
-                        }
-
-                        me.log('flowCardAction switch_scene_off  -> returned true');
-                        return resolve(true);
-
-                    });
-                });
-            })
-            .getArgument('scene')
-            .registerAutocompleteListener(async (query, args) => {
-                return this._onGetSceneAutocomplete(args)
-            });
-
-    }
-
-    _onGetSceneAutocomplete(args) {
-
-        var me = this;
-
-        if (! args.device) {
-            me.log('ERR flowCardAction switch_scene_on autocomplete - NO DEVICE');
-            return false;
+    // PRESETS
+    this.homey.flow.getConditionCard('check_preset')
+    // .register()
+      .registerRunListener(async (args, state) => {
+        if (!args.device) {
+          return false;
         }
 
         return new Promise((resolve, reject) => {
-            homewizard.callnew(args.device.getData().id, '/gplist', function(err, response) {
-                if(err) {
-                    me.log('ERR flowCardAction switch_scene_on autocomplete');
-
-                    return resolve(false);
-                }
-
-                var arrayAutocomplete = [];
-
-                for (var i = 0, len = response.length; i < len; i++) {
-                    arrayAutocomplete.push({
-                        name: response[i].name,
-                        id: response[i].id
-                    });
-                }
-
-                me.log('_onGetSceneAutocomplete result', arrayAutocomplete);
-
-                return resolve(arrayAutocomplete);
-            });
+          homewizard.callnew(args.device.getData().id, '/get-status/', (err, response) => {
+            if (err) {
+              console.log('ERR flowCardCondition  -> returned false');
+              // You can make a choice here: reject the promise with the error,
+              // or resolve it to return "false" return resolve(false); // OR: return reject(err)
+            }
+            // console.log('arg.preset '+ args.preset + ' - hw preset ' +response.preset);
+            // console.log(' flowCardCondition CheckPreset -> returned', (args.preset == response.preset));
+            return resolve(args.preset == response.preset);
+          });
         });
+      });
+
+    this.homey.flow.getActionCard('set_preset')
+    // .register()
+      .registerRunListener(async (args, state) => {
+        if (!args.device) {
+          return false;
+        }
+
+        return new Promise((resolve, reject) => {
+
+          const uri = `/preset/${args.preset}`;
+
+          homewizard.callnew(args.device.getData().id, uri, (err, response) => {
+            if (err) {
+              me.log('ERR flowCardAction set_preset  -> returned false');
+              return resolve(false);
+            }
+
+            me.log('flowCardAction set_preset  -> returned true');
+            return resolve(true);
+
+          });
+        });
+      });
+
+    // SCENES
+    this.homey.flow.getActionCard('switch_scene_on')
+    // .register()
+      .registerRunListener(async (args, state) => {
+        if (!args.device) {
+          return false;
+        }
+
+        return new Promise((resolve, reject) => {
+          homewizard.callnew(args.device.getData().id, `/gp/${args.scene.id}/on`, (err, response) => {
+            if (err) {
+              me.log('ERR flowCardAction switch_scene_on  -> returned false');
+              return resolve(false);
+            }
+
+            me.log('flowCardAction switch_scene_on  -> returned true');
+            return resolve(true);
+
+          });
+        });
+      })
+      .getArgument('scene')
+      .registerAutocompleteListener(async (query, args) => {
+        console.log('CALLED flowCardAction switch_scene_on autocomplete');
+
+        return this._onGetSceneAutocomplete(args);
+
+      });
+
+    // SCENES
+    this.homey.flow.getActionCard('switch_scene_off')
+    // .register()
+      .registerRunListener(async (args, state) => {
+        if (!args.device) {
+          return false;
+        }
+
+        return new Promise((resolve, reject) => {
+          homewizard.callnew(args.device.getData().id, `/gp/${args.scene.id}/off`, (err, response) => {
+            if (err) {
+              console.log('ERR flowCardAction switch_scene_off  -> returned false');
+              return resolve(false);
+            }
+
+            me.log('flowCardAction switch_scene_off  -> returned true');
+            return resolve(true);
+
+          });
+        });
+      })
+      .getArgument('scene')
+      .registerAutocompleteListener(async (query, args) => {
+        return this._onGetSceneAutocomplete(args);
+      });
+
+  }
+
+  _onGetSceneAutocomplete(args) {
+
+    const me = this;
+
+    if (!args.device) {
+      me.log('ERR flowCardAction switch_scene_on autocomplete - NO DEVICE');
+      return false;
     }
 
-    onPair( socket ) {
-        // Show a specific view by ID
-        socket.showView('start');
+    return new Promise((resolve, reject) => {
+      homewizard.callnew(args.device.getData().id, '/gplist', (err, response) => {
+        if (err) {
+          me.log('ERR flowCardAction switch_scene_on autocomplete');
 
-        // Show the next view
-        socket.nextView();
+          return resolve(false);
+        }
 
-        // Show the previous view
-        socket.prevView();
+        const arrayAutocomplete = [];
 
-        // Close the pair session
-        socket.done();
+        for (let i = 0, len = response.length; i < len; i++) {
+          arrayAutocomplete.push({
+            name: response[i].name,
+            id: response[i].id,
+          });
+        }
 
-        // Received when a view has changed
-        socket.setHandler('showView', async function (viewId) {
-          if (errorMsg) {
-                     Homey.app.log(`[Driver] - Show errorMsg:`, errorMsg);
-                     socket.emit('error_msg', errorMsg);
-                     errorMsg = false;
-          }
-        });
+        me.log('_onGetSceneAutocomplete result', arrayAutocomplete);
 
-        socket.setHandler('manual_add', async function (device) {
+        return resolve(arrayAutocomplete);
+      });
+    });
+  }
 
-            var url = 'http://' + device.settings.homewizard_ip + '/' + device.settings.homewizard_pass + '/get-sensors/';
+  onPair(socket) {
+    // Show a specific view by ID
+    socket.showView('start');
 
-            const json = await fetch(url).then(res => res.json())
+    // Show the next view
+    socket.nextView();
 
-            console.log('Calling '+ url);
+    // Show the previous view
+    socket.prevView();
 
-            if (json.status == 'ok') {
-              console.log('Call OK');
+    // Close the pair session
+    socket.done();
 
-              devices[device.data.id] = {
-                  id: device.data.id,
-                  name: device.name,
-                  settings: device.settings,
-                  capabilities: device.capabilities
-              };
-              homewizard.setDevices(devices);
+    // Received when a view has changed
+    socket.setHandler('showView', async (viewId) => {
+      if (errorMsg) {
+        Homey.app.log('[Driver] - Show errorMsg:', errorMsg);
+        socket.emit('error_msg', errorMsg);
+        errorMsg = false;
+      }
+    });
 
-              socket.emit("success", device);
-              return devices;
+    socket.setHandler('manual_add', async (device) => {
 
-            }
-/*
+      const url = `http://${device.settings.homewizard_ip}/${device.settings.homewizard_pass}/get-sensors/`;
+
+      const json = await fetch(url).then((res) => res.json());
+
+      console.log(`Calling ${url}`);
+
+      if (json.status == 'ok') {
+        console.log('Call OK');
+
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+          capabilities: device.capabilities,
+        };
+        homewizard.setDevices(devices);
+
+        socket.emit('success', device);
+        return devices;
+
+      }
+      /*
             request(url, function (error, response, body) {
                 if (response === null || response === undefined) {
                             socket.emit("error", "http error");
@@ -222,14 +222,12 @@ class HomeWizardDriver extends Homey.Driver {
                 }
             });
   */
-        });
+    });
 
-        socket.setHandler('disconnect', async function() {
-            console.log("User aborted pairing, or pairing is finished");
-        });
-    }
-
-
+    socket.setHandler('disconnect', async () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+  }
 
 }
 

--- a/drivers/kakusensors/device.js
+++ b/drivers/kakusensors/device.js
@@ -1,177 +1,174 @@
 'use strict';
 
 const Homey = require('homey');
-var homewizard = require('./../../includes/homewizard.js');
+const homewizard = require('../../includes/homewizard.js');
 
 const debug = false;
 
-var refreshIntervalId;
-var devices = {};
-//const thermometers = {};
+let refreshIntervalId;
+const devices = {};
+// const thermometers = {};
 
 class HomeWizardKakusensors extends Homey.Device {
 
-onInit() {
+  onInit() {
 
-		if (debug) {console.log('HomeWizard Kakusensors '+this.getName() +' has been inited');}
+    if (debug) { console.log(`HomeWizard Kakusensors ${this.getName()} has been inited`); }
 
-		const devices = this.homey.drivers.getDriver('kakusensors').getDevices();
+    const devices = this.homey.drivers.getDriver('kakusensors').getDevices();
 
-		devices.forEach(function initdevice(device) {
-			console.log('add device: ' + JSON.stringify(device.getName()));
+    devices.forEach((device) => {
+      console.log(`add device: ${JSON.stringify(device.getName())}`);
 
-			devices[device.getData().id] = device;
-			devices[device.getData().id].settings = device.getSettings();
-		});
+      devices[device.getData().id] = device;
+      devices[device.getData().id].settings = device.getSettings();
+    });
 
-		if (Object.keys(devices).length > 0) {
+    if (Object.keys(devices).length > 0) {
 		  this.startPolling(devices);
-		}
+    }
 
+  }
 
-	}
+  startPolling(devices) {
 
+    // Clear interval
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
 
-startPolling(devices) {
+    // Start polling for thermometer
+    this.refreshIntervalId = setInterval(() => {
+      if (debug) { console.log('--Start Kakusensors Polling-- '); }
 
-		
-		// Clear interval
-		if (this.refreshIntervalId) {
-			clearInterval(this.refreshIntervalId);
-		}
+      this.getStatus(devices);
 
-		// Start polling for thermometer
-		this.refreshIntervalId = setInterval(() => {
-			if (debug) {console.log("--Start Kakusensors Polling-- ");}
+    }, 1000 * 20);
 
-			this.getStatus(devices);
+  }
 
-		}, 1000 * 20 );
-
-	}
-
-	async getStatus(devices) {
-		if (debug) {
+  async getStatus(devices) {
+    if (debug) {
 		  console.log('Start Polling');
-		}
-	  
-		for (const index in devices) {
+    }
+
+    for (const index in devices) {
 		  if (devices[index].settings.homewizard_id !== undefined) {
-			const homewizard_id = devices[index].settings.homewizard_id;
-			const kakusensor_id = devices[index].settings.kakusensor_id;
-	  
-			try {
+        const { homewizard_id } = devices[index].settings;
+        const { kakusensor_id } = devices[index].settings;
+
+        try {
 			  const result = await homewizard.getDeviceData(homewizard_id, 'kakusensors');
-			  
+
 			  if (Object.keys(result).length > 0) {
-				for (const index2 in result) {
+            for (const index2 in result) {
 				  if (result[index2].id == kakusensor_id) {
-					let sensor_status_temp = result[index2].status;
-					let sensor_status = (sensor_status_temp == 'yes');
-	  
-					if (result[index2].type == "motion") {
+                const sensor_status_temp = result[index2].status;
+                const sensor_status = (sensor_status_temp == 'yes');
+
+                if (result[index2].type == 'motion') {
 					  if (!devices[index].hasCapability('alarm_motion')) {
-						await devices[index].addCapability('alarm_motion');
+                    await devices[index].addCapability('alarm_motion');
 					  }
-	  
+
 					  if (devices[index].getCapabilityValue('alarm_motion') != sensor_status) {
-						if (debug) {
-						  console.log("New status - " + sensor_status);
-						}
-	  
-						await devices[index].setCapabilityValue('alarm_motion', sensor_status);
+                    if (debug) {
+						  console.log(`New status - ${sensor_status}`);
+                    }
+
+                    await devices[index].setCapabilityValue('alarm_motion', sensor_status);
 					  }
-					}
-	  
-					if (result[index2].type == "smoke868" || result[index2].type == "smoke") {
+                }
+
+                if (result[index2].type == 'smoke868' || result[index2].type == 'smoke') {
 					  if (!devices[index].hasCapability('alarm_smoke')) {
-						await devices[index].addCapability('alarm_smoke');
+                    await devices[index].addCapability('alarm_smoke');
 					  }
-	  
+
 					  if (devices[index].getCapabilityValue('alarm_smoke') != sensor_status) {
-						if (debug) {
-						  console.log("New status - " + sensor_status);
-						}
-	  
-						await devices[index].setCapabilityValue('alarm_smoke', sensor_status);
+                    if (debug) {
+						  console.log(`New status - ${sensor_status}`);
+                    }
+
+                    await devices[index].setCapabilityValue('alarm_smoke', sensor_status);
 					  }
-					}
-	  
-					if (result[index2].type == "leakage") {
+                }
+
+                if (result[index2].type == 'leakage') {
 					  if (!devices[index].hasCapability('alarm_water')) {
-						await devices[index].addCapability('alarm_water');
+                    await devices[index].addCapability('alarm_water');
 					  }
-	  
+
 					  if (devices[index].getCapabilityValue('alarm_water') != sensor_status) {
-						if (debug) {
-						  console.log("New status - " + sensor_status);
-						}
-	  
-						await devices[index].setCapabilityValue('alarm_water', sensor_status);
+                    if (debug) {
+						  console.log(`New status - ${sensor_status}`);
+                    }
+
+                    await devices[index].setCapabilityValue('alarm_water', sensor_status);
 					  }
-					}
-	  
-					if (result[index2].type == "contact" || result[index2].type == "contact868") {
+                }
+
+                if (result[index2].type == 'contact' || result[index2].type == 'contact868') {
 					  if (!devices[index].hasCapability('alarm_contact')) {
-						await devices[index].addCapability('alarm_contact');
+                    await devices[index].addCapability('alarm_contact');
 					  }
-	  
+
 					  if (devices[index].getCapabilityValue('alarm_contact') != sensor_status) {
-						if (debug) {
-						  console.log("New status - " + sensor_status);
-						}
-	  
-						await devices[index].setCapabilityValue('alarm_contact', sensor_status);
+                    if (debug) {
+						  console.log(`New status - ${sensor_status}`);
+                    }
+
+                    await devices[index].setCapabilityValue('alarm_contact', sensor_status);
 					  }
-					}
-	  
-					if (result[index2].type == "doorbell") {
+                }
+
+                if (result[index2].type == 'doorbell') {
 					  if (!devices[index].hasCapability('alarm_generic')) {
-						await devices[index].addCapability('alarm_generic');
+                    await devices[index].addCapability('alarm_generic');
 					  }
-	  
+
 					  if (devices[index].getCapabilityValue('alarm_generic') != sensor_status) {
-						if (debug) {
-						  console.log("New status - " + sensor_status);
-						}
-	  
-						await devices[index].setCapabilityValue('alarm_generic', sensor_status);
+                    if (debug) {
+						  console.log(`New status - ${sensor_status}`);
+                    }
+
+                    await devices[index].setCapabilityValue('alarm_generic', sensor_status);
 					  }
-					}
-	  
-					if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
+                }
+
+                if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
 					  if (!devices[index].hasCapability('alarm_battery')) {
-						await devices[index].addCapability('alarm_battery');
+                    await devices[index].addCapability('alarm_battery');
 					  }
-	  
-					  let lowBattery_temp = result[index2].lowBattery;
-					  let lowBattery_status = (lowBattery_temp == 'yes');
-	  
+
+					  const lowBattery_temp = result[index2].lowBattery;
+					  const lowBattery_status = (lowBattery_temp == 'yes');
+
 					  if (devices[index].getCapabilityValue('alarm_battery') != lowBattery_status) {
-						console.log("New status - " + lowBattery_status);
-						await devices[index].setCapabilityValue('alarm_battery', lowBattery_status);
+                    console.log(`New status - ${lowBattery_status}`);
+                    await devices[index].setCapabilityValue('alarm_battery', lowBattery_status);
 					  }
-					}
+                }
 				  }
-				}
+            }
 			  }
-			} catch (err) {
+        } catch (err) {
 			  console.log(err);
-			  console.log("Kakusensors data corrupt");
-			}
+			  console.log('Kakusensors data corrupt');
+        }
 		  }
-		}
+    }
 	  }
 
-onDeleted() {
+  onDeleted() {
 
-		if (Object.keys(devices).length === 0) {
-			clearInterval(refreshIntervalId);
-			if (debug) {console.log("--Stopped Polling--");}
-		}
+    if (Object.keys(devices).length === 0) {
+      clearInterval(refreshIntervalId);
+      if (debug) { console.log('--Stopped Polling--'); }
+    }
 
-		console.log('deleted: ' + JSON.stringify(this));
-	}
+    console.log(`deleted: ${JSON.stringify(this)}`);
+  }
 
 }
 

--- a/drivers/kakusensors/driver.js
+++ b/drivers/kakusensors/driver.js
@@ -2,98 +2,96 @@
 
 const Homey = require('homey');
 
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
 
-var devices = {};
-var homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
+let homewizard_devices;
 
 class HomeWizardKakusensors extends Homey.Driver {
 
-    onInit() {
-        console.log('HomeWizard Kakusensors has been inited');
-    }
+  onInit() {
+    console.log('HomeWizard Kakusensors has been inited');
+  }
 
-    async onPair(socket) {
-        // Show a specific view by ID
-        await socket.showView('start');
+  async onPair(socket) {
+    // Show a specific view by ID
+    await socket.showView('start');
 
-        // Show the next view
-        await socket.nextView();
+    // Show the next view
+    await socket.nextView();
 
-        // Show the previous view
-        await socket.prevView();
+    // Show the previous view
+    await socket.prevView();
 
-        // Close the pair session
-        await socket.done();
+    // Close the pair session
+    await socket.done();
 
-        // Received when a view has changed
-        socket.setHandler('showView', function (viewId) {
-          console.log('View: ' + viewId);
-          //this.log("data", viewId);
+    // Received when a view has changed
+    socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      // this.log("data", viewId);
+    });
+
+    // socket.on('get_homewizards', function () {
+    socket.setHandler('get_homewizards', () => {
+
+      // homewizard_devices = driver.getDevices();
+      homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          const kakusensors = JSON.stringify(homewizard_devices[key].polldata.kakusensors);
+
+          hw_devices[key] = homewizard_devices[key];
+          hw_devices[key].polldata = {};
+          hw_devices[key].kakusensors = kakusensors;
         });
 
+        console.log(hw_devices);
+        socket.emit('hw_devices', hw_devices);
 
-        //socket.on('get_homewizards', function () {
-        socket.setHandler('get_homewizards', () => {
+      });
+    });
 
-            //homewizard_devices = driver.getDevices();
-            homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+    socket.setHandler('manual_add', (device) => {
+      if (typeof device.settings.homewizard_id == 'string' && device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`Kakusensor added ${device.data.id}`);
+        // console.log(device);
+        // console.log(device.kakusensors);
+        // console.log(device.kakusensors[device.settings.kakusensors_id].type);
 
-            homewizard.getDevices(function ( homewizard_devices)  {
-                var hw_devices = {};
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+          // data: {
+          //      capabilities: [];
+          // }
+        };
+        // callback( null, devices );
+        socket.emit('success', device);
+        return devices;
 
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    var kakusensors = JSON.stringify(homewizard_devices[key].polldata.kakusensors);
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
 
-                    hw_devices[key] = homewizard_devices[key];
-                    hw_devices[key].polldata = {}
-                    hw_devices[key].kakusensors = kakusensors;
-                });
+    });
 
-                console.log(hw_devices);
-                socket.emit('hw_devices', hw_devices);
+    socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+  }
 
-            });
-        });
+  onPairListDevices(data, callback) {
+    const devices = [
 
-        socket.setHandler('manual_add', function (device) {
-            if (typeof device.settings.homewizard_id == "string" && device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('Kakusensor added ' + device.data.id);
-                //console.log(device);
-                //console.log(device.kakusensors);
-                //console.log(device.kakusensors[device.settings.kakusensors_id].type);
+    ];
 
-
-                devices[device.data.id] = {
-                  id: device.data.id,
-                  name: device.name,
-                  settings: device.settings,
-                  //data: {
-                  //      capabilities: [];
-                  //}
-                };
-                //callback( null, devices );
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
-            }
-        });
-
-        socket.setHandler('disconnect', () => {
-            console.log("User aborted pairing, or pairing is finished");
-        });
-    }
-
-    onPairListDevices( data, callback ) {
-        const devices = [
-
-        ]
-
-        callback(null, devices);
-    }
+    callback(null, devices);
+  }
 
 }
 

--- a/drivers/plugin_battery/device.js
+++ b/drivers/plugin_battery/device.js
@@ -13,7 +13,7 @@ module.exports = class HomeWizardPluginBattery extends Homey.Device {
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
   }
@@ -44,148 +44,146 @@ module.exports = class HomeWizardPluginBattery extends Homey.Device {
       rejectUnauthorized: false,
     });
 
-    if( !this.url ) return;
+    if (!this.url) return;
 
-    const token2 = this.getData().token
-    const token = this.getStoreValue("token")
+    const token2 = this.getData().token;
+    const token = this.getStoreValue('token');
 
     if (!token) {
-      token = token2
+      token = token2;
     }
 
-    //console.log('Token: ', token);
-    //console.log('Token2: ', token2);
+    // console.log('Token: ', token);
+    // console.log('Token2: ', token2);
 
     Promise.resolve().then(async () => {
-      
-      let res = await fetch(`${this.url}/api/measurement`, {
-              headers: {
-                'Authorization': `Bearer ${token}`
-              },
-              agent: new (require('https').Agent)({ rejectUnauthorized: false }) // Ignore SSL errors
-            });
-      
-       if( !res || !res.ok )
-                 throw new Error(res ? res.statusText : 'Unknown error during fetch');
+
+      const res = await fetch(`${this.url}/api/measurement`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        agent: new (require('https').Agent)({ rejectUnauthorized: false }), // Ignore SSL errors
+      });
+
+      if (!res || !res.ok)
+      { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
 
       const data = await res.json();
 
-      //energy_import_kwh	Number	The energy usage meter reading in kWh.
-      //energy_export_kwh	Number	The energy feed-in meter reading in kWh.
-      //power_w	Number	The total active usage in watt.
-      //voltage_l1_v	Number	The active voltage in volt.
-      //current_a	Number	The active current in ampere.
-      //frequency_hz	Number	Line frequency in hertz.
-      //state_of_charge_pct	Number	The current state of charge in percent.
-      //cycles	Number	Number of battery cycles.
+      // energy_import_kwh	Number	The energy usage meter reading in kWh.
+      // energy_export_kwh	Number	The energy feed-in meter reading in kWh.
+      // power_w	Number	The total active usage in watt.
+      // voltage_l1_v	Number	The active voltage in volt.
+      // current_a	Number	The active current in ampere.
+      // frequency_hz	Number	Line frequency in hertz.
+      // state_of_charge_pct	Number	The current state of charge in percent.
+      // cycles	Number	Number of battery cycles.
 
       // Save export data check if capabilities are present first
-      
-      //energy_import_kwh
+
+      // energy_import_kwh
       if (data.energy_import_kwh !== undefined) {
         if (!this.hasCapability('meter_power.import')) {
           await this.addCapability('meter_power.import').catch(this.error);
-      }
-      if (this.getCapabilityValue('meter_power.import') != data.energy_import_kwh)
-          await this.setCapabilityValue("meter_power.import", data.energy_import_kwh).catch(this.error);
+        }
+        if (this.getCapabilityValue('meter_power.import') != data.energy_import_kwh)
+        { await this.setCapabilityValue('meter_power.import', data.energy_import_kwh).catch(this.error); }
       }
       else if ((data.energy_import_kwh == undefined) && (this.hasCapability('meter_power.import'))) {
-          await this.removeCapability('meter_power.import').catch(this.error);
+        await this.removeCapability('meter_power.import').catch(this.error);
       }
 
-      //energy_export_kwh
+      // energy_export_kwh
       if (data.energy_export_kwh !== undefined) {
         if (!this.hasCapability('meter_power.export')) {
           await this.addCapability('meter_power.export').catch(this.error);
-      }
-      if (this.getCapabilityValue('meter_power.export') != data.energy_export_kwh)
-          await this.setCapabilityValue("meter_power.export", data.energy_export_kwh).catch(this.error);
+        }
+        if (this.getCapabilityValue('meter_power.export') != data.energy_export_kwh)
+        { await this.setCapabilityValue('meter_power.export', data.energy_export_kwh).catch(this.error); }
       }
       else if ((data.energy_export_kwh == undefined) && (this.hasCapability('meter_power.export'))) {
-          await this.removeCapability('meter_power.export').catch(this.error);
+        await this.removeCapability('meter_power.export').catch(this.error);
       }
 
-      //power_w
+      // power_w
       if (data.power_w !== undefined) {
         if (!this.hasCapability('measure_power')) {
           await this.addCapability('measure_power').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_power') != data.power_w)
-          await this.setCapabilityValue("measure_power", data.power_w).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_power') != data.power_w)
+        { await this.setCapabilityValue('measure_power', data.power_w).catch(this.error); }
       }
       else if ((data.power_w == undefined) && (this.hasCapability('measure_power'))) {
-          await this.removeCapability('measure_power').catch(this.error);
+        await this.removeCapability('measure_power').catch(this.error);
       }
 
-      //voltage_l1_v
+      // voltage_l1_v
       if (data.voltage_l1_v !== undefined) {
         if (!this.hasCapability('measure_voltage')) {
           await this.addCapability('measure_voltage').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_voltage') != data.voltage_l1_v)
-        await this.setCapabilityValue("measure_voltage", data.voltage_l1_v).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_voltage') != data.voltage_l1_v)
+        { await this.setCapabilityValue('measure_voltage', data.voltage_l1_v).catch(this.error); }
       }
       else if ((data.voltage_l1_v == undefined) && (this.hasCapability('measure_voltage'))) {
         await this.removeCapability('measure_voltage').catch(this.error);
       }
 
-      //current_a  Amp's 
+      // current_a  Amp's
       if (data.current_a !== undefined) {
         if (!this.hasCapability('measure_current')) {
           await this.addCapability('measure_current').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_current') != data.current_a)
-          await this.setCapabilityValue("measure_current", data.current_a).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_current') != data.current_a)
+        { await this.setCapabilityValue('measure_current', data.current_a).catch(this.error); }
       }
       else if ((data.current_a == undefined) && (this.hasCapability('measure_current'))) {
-          await this.removeCapability('measure_current').catch(this.error);
+        await this.removeCapability('measure_current').catch(this.error);
       }
 
-      //measure_battery
+      // measure_battery
       if (data.state_of_charge_pct !== undefined) {
         if (!this.hasCapability('measure_battery')) {
           await this.addCapability('measure_battery').catch(this.error);
-      }
-      if (this.getCapabilityValue('measure_battery') != data.state_of_charge_pct)
-          await this.setCapabilityValue("measure_battery", data.state_of_charge_pct).catch(this.error);
+        }
+        if (this.getCapabilityValue('measure_battery') != data.state_of_charge_pct)
+        { await this.setCapabilityValue('measure_battery', data.state_of_charge_pct).catch(this.error); }
       }
       else if ((data.state_of_charge_pct == undefined) && (this.hasCapability('measure_battery'))) {
-          await this.removeCapability('measure_battery').catch(this.error);
+        await this.removeCapability('measure_battery').catch(this.error);
       }
 
-      //Round Trup Efficiency energy_export_kwh / energy_import_kwh * 100
+      // Round Trup Efficiency energy_export_kwh / energy_import_kwh * 100
 
-      //battery_charging_state - not support by HW battery
+      // battery_charging_state - not support by HW battery
       if (data.power_w > 0) {
-        await this.setCapabilityValue('battery_charging_state', "charging").catch(this.error);
+        await this.setCapabilityValue('battery_charging_state', 'charging').catch(this.error);
 
       } else if (data.power_w < 0) {
-        await this.setCapabilityValue('battery_charging_state', "discharging").catch(this.error);
+        await this.setCapabilityValue('battery_charging_state', 'discharging').catch(this.error);
 
       } else {
-        await this.setCapabilityValue('battery_charging_state', "idle").catch(this.error);
+        await this.setCapabilityValue('battery_charging_state', 'idle').catch(this.error);
       }
-      
 
       // battery Cycles - custom metric needs to be added
 
       if (data.cycles !== undefined) {
         if (!this.hasCapability('cycles')) {
-         await this.addCapability('cycles').catch(this.error);
+          await this.addCapability('cycles').catch(this.error);
+        }
+        if (this.getCapabilityValue('cycles') != data.cycles)
+        { await this.setCapabilityValue('cycles', data.cycles).catch(this.error); }
       }
-      if (this.getCapabilityValue('cycles') != data.cycles)
-          await this.setCapabilityValue("cycles", data.cycles).catch(this.error);
-      }
-
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         this.error(err);
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
-}
+};

--- a/drivers/plugin_battery/driver.js
+++ b/drivers/plugin_battery/driver.js
@@ -8,89 +8,88 @@ module.exports = class HomeWizardEnergyDriverV2 extends Homey.Driver {
 
   async onPair(session) {
 
-    session.setHandler("list_devices", async () => {
+    session.setHandler('list_devices', async () => {
 
-            const httpsAgent = new https.Agent({
-              rejectUnauthorized: false, //ignore SSL errors
-            });
-        
-            const discoveryStrategy = this.getDiscoveryStrategy();
-            const discoveryResults = discoveryStrategy.getDiscoveryResults();
-            const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
-            
-            const devices = [];
-            await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
-              try {
-        
-                // start.html -> Confirmation pressing button on device
-                const payload = {
-                  name: 'local/homey_user'
-                };
-                
-                const response  = await fetch(`https://${discoveryResult.address}/api/user`, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'X-Api-Version': '2'
-                  },
-                  body: JSON.stringify(payload),
-                  agent: new (require('https').Agent)({ rejectUnauthorized: false }),
-                  
-                });
-        
-                //if (!response.ok) {
-                //  throw new Error(`Error: ${response.statusText}`);
-                //}
-        
-        
-                const result = await response.json();
-                console.log("Result received: ", result);
-        
-                //const responseData = await result.json();
-                const bearer_token = result.token;
-        
-                console.log("Bearer token: ", result.token);
-                
-                const res = await fetch(`https://${discoveryResult.address}/api`, {
-                  headers: {
-                    'Authorization': `Bearer ${bearer_token}`
-                  },
-                  agent: new (require('https').Agent)({ rejectUnauthorized: false }) // Ignore SSL errors
-                });
-        
-                if( !res.ok )
-                  throw new Error(res.statusText);
-        
-                const data = await res.json();
-                
-                let name = data.product_name
-                if (numberOfDiscoveryResults > 1) {
-                  name = `${data.product_name} (${data.serial})`
-                }
-        
-                devices.push({
-                  name: name,
-                  data: {
-                    id: discoveryResult.id,
-                  },
-                  store: {
-                    token: bearer_token,
-                  }
-                })
-              } catch( err ) {
-                this.error(discoveryResult.id, err);
-              }
-            }));
-            return devices;
+      const httpsAgent = new https.Agent({
+        rejectUnauthorized: false, // ignore SSL errors
+      });
+
+      const discoveryStrategy = this.getDiscoveryStrategy();
+      const discoveryResults = discoveryStrategy.getDiscoveryResults();
+      const numberOfDiscoveryResults = Object.keys(discoveryResults).length;
+
+      const devices = [];
+      await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
+        try {
+
+          // start.html -> Confirmation pressing button on device
+          const payload = {
+            name: 'local/homey_user',
+          };
+
+          const response = await fetch(`https://${discoveryResult.address}/api/user`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Api-Version': '2',
+            },
+            body: JSON.stringify(payload),
+            agent: new (require('https').Agent)({ rejectUnauthorized: false }),
+
           });
 
-          session.setHandler('showView', async (view) => {
-            if (view === 'loading') {
-              
-              await session.nextView();
-            }
+          // if (!response.ok) {
+          //  throw new Error(`Error: ${response.statusText}`);
+          // }
+
+          const result = await response.json();
+          console.log('Result received: ', result);
+
+          // const responseData = await result.json();
+          const bearer_token = result.token;
+
+          console.log('Bearer token: ', result.token);
+
+          const res = await fetch(`https://${discoveryResult.address}/api`, {
+            headers: {
+              Authorization: `Bearer ${bearer_token}`,
+            },
+            agent: new (require('https').Agent)({ rejectUnauthorized: false }), // Ignore SSL errors
           });
 
-}
+          if (!res.ok)
+          { throw new Error(res.statusText); }
 
-}
+          const data = await res.json();
+
+          let name = data.product_name;
+          if (numberOfDiscoveryResults > 1) {
+            name = `${data.product_name} (${data.serial})`;
+          }
+
+          devices.push({
+            name,
+            data: {
+              id: discoveryResult.id,
+            },
+            store: {
+              token: bearer_token,
+            },
+          });
+        } catch (err) {
+          this.error(discoveryResult.id, err);
+        }
+      }));
+      return devices;
+    });
+
+    session.setHandler('showView', async (view) => {
+      if (view === 'loading') {
+
+        await session.nextView();
+      }
+    });
+
+  }
+
+};

--- a/drivers/rainmeter/device.js
+++ b/drivers/rainmeter/device.js
@@ -1,129 +1,124 @@
 'use strict';
 
 const Homey = require('homey');
-var homewizard = require('./../../includes/homewizard.js');
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('rainmeter');
+const homewizard = require('../../includes/homewizard.js');
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('rainmeter');
 
-var refreshIntervalId;
-var devices = {};
-//var temperature;
+let refreshIntervalId;
+const devices = {};
+// var temperature;
 
 class HomeWizardRainmeter extends Homey.Device {
 
-	onInit() {
+  onInit() {
 
-		console.log('HomeWizard Rainmeter '+this.getName() +' has been inited');
+    console.log(`HomeWizard Rainmeter ${this.getName()} has been inited`);
 
-		const devices = this.homey.drivers.getDriver('rainmeter').getDevices();
-		devices.forEach(function initdevice(device) {
-			console.log('add device: ' + JSON.stringify(device.getName()));
+    const devices = this.homey.drivers.getDriver('rainmeter').getDevices();
+    devices.forEach((device) => {
+      console.log(`add device: ${JSON.stringify(device.getName())}`);
 
-			devices[device.getData().id] = device;
-			devices[device.getData().id].settings = device.getSettings();
-		});
+      devices[device.getData().id] = device;
+      devices[device.getData().id].settings = device.getSettings();
+    });
 
-		this.startPolling();
+    this.startPolling();
 
-		this._flowTriggerValueChanged = this.homey.flow.getDeviceTriggerCard('rainmeter_value_changed');
+    this._flowTriggerValueChanged = this.homey.flow.getDeviceTriggerCard('rainmeter_value_changed');
 
-	}
+  }
 
-	flowTriggerValueChanged( device, tokens ) {
-		this._flowTriggerValueChanged.trigger( device, tokens ).catch( this.error )
-	}
+  flowTriggerValueChanged(device, tokens) {
+    this._flowTriggerValueChanged.trigger(device, tokens).catch(this.error);
+  }
 
+  startPolling() {
 
-	startPolling() {
+    // Clear interval
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
 
-		// Clear interval
-		if (this.refreshIntervalId) {
-			clearInterval(this.refreshIntervalId);
-		}
+    // Start polling for thermometer
+    this.refreshIntervalId = setInterval(() => {
+      // console.log("--Start Rainmeter Polling-- ");
 
-		// Start polling for thermometer
-		this.refreshIntervalId = setInterval(() => {
-			//console.log("--Start Rainmeter Polling-- ");
+      this.getStatus();
 
-			this.getStatus();
+    }, 1000 * 20);
 
-		}, 1000 * 20 );
+  }
 
-	}
+  async getStatus() {
+    Promise.resolve()
+      .then(async () => {
 
-	async getStatus() {
-		Promise.resolve()
-		.then(async () => {
+        const me = this;
 
-					const me = this;
-			
-				if (this.getSetting('homewizard_id') !== undefined) {
-					const homewizard_id = this.getSetting('homewizard_id');
-					const callback = await homewizard.getDeviceData(homewizard_id, 'rainmeters');
-			
-					if (Object.keys(callback).length > 0) {
-						try {
-							//me.setAvailable();
+        if (this.getSetting('homewizard_id') !== undefined) {
+          const homewizard_id = this.getSetting('homewizard_id');
+          const callback = await homewizard.getDeviceData(homewizard_id, 'rainmeters');
 
-							//Check Battery
-							if (callback[0].lowBattery != undefined && callback[0].lowBattery != null) {
-								if (!this.hasCapability('alarm_battery')) {
-								await this.addCapability('alarm_battery').catch(me.error);
-								}
-				
-								let lowBattery_temp = callback[0].lowBattery;
-								let lowBattery_status = lowBattery_temp == 'yes';
-				
-								if (this.getCapabilityValue('alarm_battery') != lowBattery_status) {
-								//if (debug) { console.log("New status - " + lowBattery_status); }
-								await this.setCapabilityValue('alarm_battery', lowBattery_status).catch(me.error);
-								}
-							} else {
-								if (this.hasCapability('alarm_battery')) {
-								await this.removeCapability('alarm_battery').catch(me.error);
-								}
-							}
+          if (Object.keys(callback).length > 0) {
+            try {
+              // me.setAvailable();
 
-			
-							let rain_daytotal = callback[0].mm; // Total Rain in mm used JSON $rainmeters[0]['mm']
-							let rain_last3h = callback[0]['3h']; // Last 3 hours rain in mm used JSON $rainmeters[0]['3h']
-							
-							// Rain last 3 hours
-							await me.setCapabilityValue("measure_rain.last3h", rain_last3h).catch(me.error);
-							
-							// Rain total day
-							await me.setCapabilityValue("measure_rain.total", rain_daytotal).catch(me.error);
-							
-							// Trigger flows
-							if (rain_daytotal != me.getStoreValue("last_raintotal") && rain_daytotal != 0 && rain_daytotal != undefined && rain_daytotal != null) {
-								me.flowTriggerValueChanged(me, { rainmeter_changed: rain_daytotal });
-								await me.setStoreValue("last_raintotal", rain_daytotal).catch(me.error); // Update last_raintotal
-							}
-						} catch (err) {
-							console.log('ERROR RainMeter getStatus ', err);
-							me.setUnavailable();
-						}
-					}
-				} else {
-					console.log('Rainmeter settings not found, stop polling set unavailable');
-					//this.setUnavailable();
-			
-					// Only clear interval when the unavailable device is the only device on this driver
-					// This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
-					// In the event that a user has multiple devices with old settings, this function will get called every 10 seconds, but that should not be a problem
-				}
-		})
-		.then(() => {
-			this.setAvailable().catch(this.error);
-		})
-		.catch(err => {
-			this.error(err);
-			this.setUnavailable(err).catch(this.error);
-		});
-	}
-	
+              // Check Battery
+              if (callback[0].lowBattery != undefined && callback[0].lowBattery != null) {
+                if (!this.hasCapability('alarm_battery')) {
+                  await this.addCapability('alarm_battery').catch(me.error);
+                }
 
-	/*
+                const lowBattery_temp = callback[0].lowBattery;
+                const lowBattery_status = lowBattery_temp == 'yes';
+
+                if (this.getCapabilityValue('alarm_battery') != lowBattery_status) {
+                  // if (debug) { console.log("New status - " + lowBattery_status); }
+                  await this.setCapabilityValue('alarm_battery', lowBattery_status).catch(me.error);
+                }
+              } else if (this.hasCapability('alarm_battery')) {
+                await this.removeCapability('alarm_battery').catch(me.error);
+              }
+
+              const rain_daytotal = callback[0].mm; // Total Rain in mm used JSON $rainmeters[0]['mm']
+              const rain_last3h = callback[0]['3h']; // Last 3 hours rain in mm used JSON $rainmeters[0]['3h']
+
+              // Rain last 3 hours
+              await me.setCapabilityValue('measure_rain.last3h', rain_last3h).catch(me.error);
+
+              // Rain total day
+              await me.setCapabilityValue('measure_rain.total', rain_daytotal).catch(me.error);
+
+              // Trigger flows
+              if (rain_daytotal != me.getStoreValue('last_raintotal') && rain_daytotal != 0 && rain_daytotal != undefined && rain_daytotal != null) {
+                me.flowTriggerValueChanged(me, { rainmeter_changed: rain_daytotal });
+                await me.setStoreValue('last_raintotal', rain_daytotal).catch(me.error); // Update last_raintotal
+              }
+            } catch (err) {
+              console.log('ERROR RainMeter getStatus ', err);
+              me.setUnavailable();
+            }
+          }
+        } else {
+          console.log('Rainmeter settings not found, stop polling set unavailable');
+          // this.setUnavailable();
+
+          // Only clear interval when the unavailable device is the only device on this driver
+          // This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
+          // In the event that a user has multiple devices with old settings, this function will get called every 10 seconds, but that should not be a problem
+        }
+      })
+      .then(() => {
+        this.setAvailable().catch(this.error);
+      })
+      .catch((err) => {
+        this.error(err);
+        this.setUnavailable(err).catch(this.error);
+      });
+  }
+
+  /*
 	getStatus() {
 
 		var me = this;
@@ -164,20 +159,19 @@ class HomeWizardRainmeter extends Homey.Device {
 			// This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
 			// In the event that a user has multiple devices with old settings this function will get called every 10 seconds but that should not be a problem
 
-
 		}
 	}
 	*/
 
-	onDeleted() {
+  onDeleted() {
 
-		if (Object.keys(devices).length === 0) {
-			clearInterval(refreshIntervalId);
-			console.log("--Stopped Polling--");
-		}
+    if (Object.keys(devices).length === 0) {
+      clearInterval(refreshIntervalId);
+      console.log('--Stopped Polling--');
+    }
 
-		console.log('deleted: ' + JSON.stringify(this));
-	}
+    console.log(`deleted: ${JSON.stringify(this)}`);
+  }
 
 }
 

--- a/drivers/rainmeter/driver.js
+++ b/drivers/rainmeter/driver.js
@@ -2,78 +2,79 @@
 
 const Homey = require('homey');
 
-var devices = {};
-var homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let homewizard_devices;
 
 class HomeWizardRainmeter extends Homey.Driver {
 
   onInit() {
-        console.log('HomeWizard Rainmeter has been inited');
-    }
+    console.log('HomeWizard Rainmeter has been inited');
+  }
 
-    async onPair(socket) {
+  async onPair(socket) {
 
-        // Show a specific view by ID
-        await socket.showView('start');
+    // Show a specific view by ID
+    await socket.showView('start');
 
-        // Show the next view
-        await socket.nextView();
+    // Show the next view
+    await socket.nextView();
 
-        // Show the previous view
-        await socket.prevView();
+    // Show the previous view
+    await socket.prevView();
 
-        // Close the pair session
-        await socket.done();
+    // Close the pair session
+    await socket.done();
 
-        // Received when a view has changed
-        socket.setHandler('showView', function (viewId) {
-          console.log('View: ' + viewId);
-          //this.log("data", viewId);
+    // Received when a view has changed
+    socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      // this.log("data", viewId);
+    });
+
+    // socket.on('get_homewizards', function () {
+    socket.setHandler('get_homewizards', () => {
+
+      // homewizard_devices = driver.getDevices();
+      homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          hw_devices[key] = homewizard_devices[key];
         });
 
-        //socket.on('get_homewizards', function () {
-        socket.setHandler('get_homewizards', () => {
+        console.log(hw_devices);
+        socket.emit('hw_devices', hw_devices);
 
-            //homewizard_devices = driver.getDevices();
-            homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+      });
+    });
 
-            homewizard.getDevices(function ( homewizard_devices)  {
-                var hw_devices = {};
+    socket.setHandler('manual_add', (device) => {
 
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    hw_devices[key] = homewizard_devices[key];
-                });
+      if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`Rainmeter added ${device.data.id}`);
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+        };
+        socket.emit('success', device);
+        return devices;
 
-                console.log(hw_devices);
-                socket.emit('hw_devices', hw_devices);
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
 
-            });
-        });
+    });
 
-        socket.setHandler('manual_add', function (device) {
+    socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
 
-            if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('Rainmeter added ' + device.data.id);
-                devices[device.data.id] = {
-                    id: device.data.id,
-                    name: device.name,
-                    settings: device.settings,
-                };
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
-            }
-        });
-
-        socket.setHandler('disconnect', function(){
-            console.log("User aborted pairing, or pairing is finished");
-        });
-
-    }
+  }
 
 }
 

--- a/drivers/thermometer/device.js
+++ b/drivers/thermometer/device.js
@@ -1,128 +1,124 @@
 'use strict';
 
 const Homey = require('homey');
-var homewizard = require('./../../includes/homewizard.js');
+const homewizard = require('../../includes/homewizard.js');
 
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('thermometer');
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('thermometer');
 
-var refreshIntervalId;
-var devices = {};
-//const thermometers = {};
-var debug = false;
+let refreshIntervalId;
+const devices = {};
+// const thermometers = {};
+const debug = false;
 
 class HomeWizardThermometer extends Homey.Device {
 
-	onInit() {
+  onInit() {
 
-		if (debug) {console.log('HomeWizard Thermometer '+this.getName() +' has been inited');}
+    if (debug) { console.log(`HomeWizard Thermometer ${this.getName()} has been inited`); }
 
-		const devices = this.homey.drivers.getDriver('thermometer').getDevices();
+    const devices = this.homey.drivers.getDriver('thermometer').getDevices();
 
-		devices.forEach(function initdevice(device) {
-			if (debug) {console.log('add device: ' + JSON.stringify(device.getName()));}
-			devices[device.getData().id] = device;
-			devices[device.getData().id].settings = device.getSettings();
-		});
+    devices.forEach((device) => {
+      if (debug) { console.log(`add device: ${JSON.stringify(device.getName())}`); }
+      devices[device.getData().id] = device;
+      devices[device.getData().id].settings = device.getSettings();
+    });
 
-		if (Object.keys(devices).length > 0) {
+    if (Object.keys(devices).length > 0) {
 		  this.startPolling(devices);
-		}
-	}
+    }
+  }
 
-	startPolling(devices) {
+  startPolling(devices) {
 
-		// Clear interval
-		if (this.refreshIntervalId) {
-			clearInterval(this.refreshIntervalId);
-		}
+    // Clear interval
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
 
-		// Start polling for thermometer
-		this.refreshIntervalId = setInterval(() => {
-			if (debug) {console.log("--Start Thermometer Polling-- ");}
+    // Start polling for thermometer
+    this.refreshIntervalId = setInterval(() => {
+      if (debug) { console.log('--Start Thermometer Polling-- '); }
 
-			this.getStatus(devices);
+      this.getStatus(devices);
 
-		}, 1000 * 20 );
+    }, 1000 * 20);
 
-	}
+  }
 
+  async getStatus(devices) {
+    try {
+		  const promises = devices.map(async (device) => { // parallel processing using Promise.all
+        if (device.settings.homewizard_id !== undefined) {
+			  const { homewizard_id } = device.settings;
+			  const { thermometer_id } = device.settings;
 
-	async getStatus(devices) {
-		try {
-		  const promises = devices.map(async (device) => {  //parallel processing using Promise.all
-			if (device.settings.homewizard_id !== undefined) {
-			  const homewizard_id = device.settings.homewizard_id;
-			  const thermometer_id = device.settings.thermometer_id;
-			  
 			  const result = await homewizard.getDeviceData(homewizard_id, 'thermometers');
-	  
+
 			  if (Object.keys(result).length > 0) {
-				for (const index2 in result) {
+            for (const index2 in result) {
 				  if (
-					result[index2].id == thermometer_id &&
-					result[index2].te != undefined &&
-					result[index2].hu != undefined &&
-					typeof result[index2].te != 'undefined' &&
-					typeof result[index2].hu != 'undefined'
+                result[index2].id == thermometer_id
+					&& result[index2].te != undefined
+					&& result[index2].hu != undefined
+					&& typeof result[index2].te != 'undefined'
+					&& typeof result[index2].hu != 'undefined'
 				  ) {
-					let te = (result[index2].te.toFixed(1) * 2) / 2;
-					let hu = (result[index2].hu.toFixed(1) * 2) / 2;
-	  
-					// First adjust retrieved temperature with offset
-					let offset_temp = device.getSetting('offset_temperature');
-					te += offset_temp;
-	  
-					// Check current temperature
-					if (device.getCapabilityValue('measure_temperature') != te) {
-					  if (debug) { console.log("New TE - " + te); }
+                let te = (result[index2].te.toFixed(1) * 2) / 2;
+                let hu = (result[index2].hu.toFixed(1) * 2) / 2;
+
+                // First adjust retrieved temperature with offset
+                const offset_temp = device.getSetting('offset_temperature');
+                te += offset_temp;
+
+                // Check current temperature
+                if (device.getCapabilityValue('measure_temperature') != te) {
+					  if (debug) { console.log(`New TE - ${te}`); }
 					  await device.setCapabilityValue('measure_temperature', te).catch(this.error);
-					}
-	  
-					// First adjust retrieved humidity with offset
-					let offset_hu = device.getSetting('offset_humidity');
-					hu += offset_hu;
-	  
-					// Check current humidity
-					if (device.getCapabilityValue('measure_humidity') != hu) {
-					  if (debug) { console.log("New HU - " + hu); }
+                }
+
+                // First adjust retrieved humidity with offset
+                const offset_hu = device.getSetting('offset_humidity');
+                hu += offset_hu;
+
+                // Check current humidity
+                if (device.getCapabilityValue('measure_humidity') != hu) {
+					  if (debug) { console.log(`New HU - ${hu}`); }
 					  await device.setCapabilityValue('measure_humidity', hu).catch(this.error);
-					}
-	  
-					if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
+                }
+
+                if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
 					  if (!device.hasCapability('alarm_battery')) {
-						await device.addCapability('alarm_battery').catch(this.error);
+                    await device.addCapability('alarm_battery').catch(this.error);
 					  }
-	  
-					  let lowBattery_temp = result[index2].lowBattery;
-					  let lowBattery_status = lowBattery_temp == 'yes';
-	  
+
+					  const lowBattery_temp = result[index2].lowBattery;
+					  const lowBattery_status = lowBattery_temp == 'yes';
+
 					  if (device.getCapabilityValue('alarm_battery') != lowBattery_status) {
-						if (debug) { console.log("New status - " + lowBattery_status); }
-						await device.setCapabilityValue('alarm_battery', lowBattery_status).catch(this.error);
+                    if (debug) { console.log(`New status - ${lowBattery_status}`); }
+                    await device.setCapabilityValue('alarm_battery', lowBattery_status).catch(this.error);
 					  }
-					} else {
-					  if (device.hasCapability('alarm_battery')) {
-						await device.removeCapability('alarm_battery').catch(this.error);
+                } else if (device.hasCapability('alarm_battery')) {
+                  await device.removeCapability('alarm_battery').catch(this.error);
 					  }
-					}
 				  }
-				}
+            }
 			  }
-			}
+        }
 		  });
-	  
+
 		  await Promise.all(promises);
-	  
+
 		  await this.setAvailable().catch(this.error);
-		} catch (err) {
+    } catch (err) {
 		  this.error(err);
 		  await this.setUnavailable(err).catch(this.error);
-		}
+    }
 	  }
-	  
 
-	/*
+  /*
 	async getStatus(devices) {
 		try {
 			for (const index in devices) {
@@ -130,7 +126,7 @@ class HomeWizardThermometer extends Homey.Device {
 					const homewizard_id = devices[index].settings.homewizard_id;
 					const thermometer_id = devices[index].settings.thermometer_id;
 					const result = await homewizard.getDeviceData(homewizard_id, 'thermometers');
-	
+
 					if (Object.keys(result).length > 0) {
 						try {
 							for (const index2 in result) {
@@ -143,35 +139,35 @@ class HomeWizardThermometer extends Homey.Device {
 								) {
 									let te = (result[index2].te.toFixed(1) * 2) / 2;
 									let hu = (result[index2].hu.toFixed(1) * 2) / 2;
-	
+
 									// First adjust retrieved temperature with offset
 									let offset_temp = devices[index].getSetting('offset_temperature');
 									te += offset_temp;
-	
+
 									// Check current temperature
 									if (devices[index].getCapabilityValue('measure_temperature') != te) {
 										if (debug) { console.log("New TE - " + te); }
 										devices[index].setCapabilityValue('measure_temperature', te);
 									}
-	
+
 									// First adjust retrieved humidity with offset
 									let offset_hu = devices[index].getSetting('offset_humidity');
 									hu += offset_hu;
-	
+
 									// Check current humidity
 									if (devices[index].getCapabilityValue('measure_humidity') != hu) {
 										if (debug) { console.log("New HU - " + hu); }
 										devices[index].setCapabilityValue('measure_humidity', hu);
 									}
-	
+
 									if (result[index2].lowBattery != undefined && result[index2].lowBattery != null) {
 										if (!devices[index].hasCapability('alarm_battery')) {
 											await devices[index].addCapability('alarm_battery').catch(this.error);
 										}
-	
+
 										let lowBattery_temp = result[index2].lowBattery;
 										let lowBattery_status = lowBattery_temp == 'yes';
-	
+
 										if (devices[index].getCapabilityValue('alarm_battery') != lowBattery_status) {
 											if (debug) { console.log("New status - " + lowBattery_status); }
 											devices[index].setCapabilityValue('alarm_battery', lowBattery_status);
@@ -195,38 +191,32 @@ class HomeWizardThermometer extends Homey.Device {
 			await this.setUnavailable(err).catch(this.error);
 		}
 	}
-	
+
 	*/
 
+  onDeleted() {
 
+    if (Object.keys(devices).length === 0) {
+      clearInterval(refreshIntervalId);
+      if (debug) { console.log('--Stopped Polling--'); }
+    }
 
-	onDeleted() {
-
-		if (Object.keys(devices).length === 0) {
-			clearInterval(refreshIntervalId);
-			if (debug) {console.log("--Stopped Polling--");}
-		}
-
-		console.log('deleted: ' + JSON.stringify(this));
-	}
-
-
-
-
+    console.log(`deleted: ${JSON.stringify(this)}`);
+  }
 
   // Catch offset updates
   onSettings(oldSettings, newSettings, changedKeys) {
-    this.log('Settings updated')
+    this.log('Settings updated');
     // Update display values if offset has changed
-    for (let k in changedKeys) {
-      let key = changedKeys[k]
+    for (const k in changedKeys) {
+      const key = changedKeys[k];
       if (key.slice(0, 7) === 'offset_') {
-        let cap = 'measure_' + key.slice(7)
-        let value = this.getCapabilityValue(cap)
-        let delta = newSettings[key] - oldSettings[key]
-        this.log('Updating value of', cap, 'from', value, 'to', value + delta)
+        const cap = `measure_${key.slice(7)}`;
+        const value = this.getCapabilityValue(cap);
+        const delta = newSettings[key] - oldSettings[key];
+        this.log('Updating value of', cap, 'from', value, 'to', value + delta);
         this.setCapabilityValue(cap, value + delta)
-          .catch(err => this.error(err))
+          .catch((err) => this.error(err));
       }
     }
 
@@ -234,17 +224,16 @@ class HomeWizardThermometer extends Homey.Device {
 
   updateValue(cap, value) {
     // add offset if defined
-    this.log('Updating value of', this.id, 'with capability', cap, 'to', value)
-    let cap_offset = cap.replace('measure', 'offset')
-    let offset = this.getSetting(cap_offset)
-    this.log(cap_offset, offset)
+    this.log('Updating value of', this.id, 'with capability', cap, 'to', value);
+    const cap_offset = cap.replace('measure', 'offset');
+    const offset = this.getSetting(cap_offset);
+    this.log(cap_offset, offset);
     if (offset != null) {
-      value += offset
+      value += offset;
     }
     this.setCapabilityValue(cap, value)
-      .catch(err => this.error(err))
+      .catch((err) => this.error(err));
   }
-
 
 }
 

--- a/drivers/thermometer/driver.js
+++ b/drivers/thermometer/driver.js
@@ -2,88 +2,88 @@
 
 const Homey = require('homey');
 
-var devices = {};
-var homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let homewizard_devices;
 
 class HomeWizardThermometer extends Homey.Driver {
 
-    onInit() {
-        console.log('HomeWizard Thermometer has been inited');
-    }
+  onInit() {
+    console.log('HomeWizard Thermometer has been inited');
+  }
 
-    async onPair(socket) {
-        // Show a specific view by ID
-        await socket.showView('start');
+  async onPair(socket) {
+    // Show a specific view by ID
+    await socket.showView('start');
 
-        // Show the next view
-        await socket.nextView();
+    // Show the next view
+    await socket.nextView();
 
-        // Show the previous view
-        await socket.prevView();
+    // Show the previous view
+    await socket.prevView();
 
-        // Close the pair session
-        await socket.done();
+    // Close the pair session
+    await socket.done();
 
-        // Received when a view has changed
-        await socket.setHandler('showView', function (viewId) {
-          console.log('View: ' + viewId);
-          //this.log("data", viewId);
+    // Received when a view has changed
+    await socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      // this.log("data", viewId);
+    });
+
+    // socket.on('get_homewizards', function () {
+    await socket.setHandler('get_homewizards', async () => {
+
+      // homewizard_devices = driver.getDevices();
+      homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          const thermometers = JSON.stringify(homewizard_devices[key].polldata.thermometers);
+
+          hw_devices[key] = homewizard_devices[key];
+          hw_devices[key].polldata = {};
+          hw_devices[key].thermometers = thermometers;
         });
 
+        console.log(hw_devices);
+        socket.emit('hw_devices', hw_devices);
 
-        //socket.on('get_homewizards', function () {
-        await socket.setHandler('get_homewizards', async () => {
+      });
+    });
 
-            //homewizard_devices = driver.getDevices();
-            homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+    await socket.setHandler('manual_add', (device) => {
+      if (typeof device.settings.homewizard_id == 'string' && device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`Thermometer added ${device.data.id}`);
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+        };
+        socket.emit('success', device);
+        return devices;
 
-            homewizard.getDevices(function ( homewizard_devices)  {
-                let hw_devices = {};
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
 
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    const thermometers = JSON.stringify(homewizard_devices[key].polldata.thermometers);
+    });
 
-                    hw_devices[key] = homewizard_devices[key];
-                    hw_devices[key].polldata = {}
-                    hw_devices[key].thermometers = thermometers;
-                });
+    await socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+  }
 
-                console.log(hw_devices);
-                socket.emit('hw_devices', hw_devices);
+  onPairListDevices(data, callback) {
+    const devices = [
 
-            });
-        });
+    ];
 
-        await socket.setHandler('manual_add', function (device) {
-            if (typeof device.settings.homewizard_id == "string" && device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('Thermometer added ' + device.data.id);
-                devices[device.data.id] = {
-                  id: device.data.id,
-                  name: device.name,
-                  settings: device.settings,
-                };
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
-            }
-        });
-
-        await socket.setHandler('disconnect', () => {
-            console.log("User aborted pairing, or pairing is finished");
-        });
-    }
-
-    onPairListDevices( data, callback ) {
-        const devices = [
-
-        ]
-
-        callback(null, devices);
-    }
+    callback(null, devices);
+  }
 
 }
 

--- a/drivers/watermeter/device.js
+++ b/drivers/watermeter/device.js
@@ -12,7 +12,7 @@ module.exports = class HomeWizardEnergyWatermeterDevice extends Homey.Device {
   }
 
   onDeleted() {
-    if( this.onPollInterval ) {
+    if (this.onPollInterval) {
       clearInterval(this.onPollInterval);
     }
   }
@@ -38,22 +38,22 @@ module.exports = class HomeWizardEnergyWatermeterDevice extends Homey.Device {
   }
 
   onPoll() {
-    if( !this.url ) return;
+    if (!this.url) return;
 
     Promise.resolve().then(async () => {
       let res = await fetch(`${this.url}/data`);
-      
-      if( !res || !res.ok ) {
-        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users 
+
+      if (!res || !res.ok) {
+        await new Promise((resolve) => setTimeout(resolve, 60000)); // wait 60s to avoid false reports due to bad wifi from users
         // try again
         res = await fetch(`${this.url}/data`);
-        if( !res || !res.ok )
-          throw new Error(res ? res.statusText : 'Unknown error during fetch');
+        if (!res || !res.ok)
+        { throw new Error(res ? res.statusText : 'Unknown error during fetch'); }
       }
 
       const data = await res.json();
 
-      var offset_water_m3;
+      let offset_water_m3;
 
       // if watermeter offset is set in Homewizard Energy app take that value else use the configured value in Homey Homewizard water offset
       if (data.total_liter_offset_m3 = '0') {
@@ -76,55 +76,55 @@ module.exports = class HomeWizardEnergyWatermeterDevice extends Homey.Device {
         await this.addCapability('rssi').catch(this.error);
       }
 
-      let temp_total_liter_m3 = data.total_liter_m3 + offset_water_m3;
+      const temp_total_liter_m3 = data.total_liter_m3 + offset_water_m3;
 
       // Update values
       if (this.getCapabilityValue('measure_water') != data.active_liter_lpm)
-        await this.setCapabilityValue('measure_water', data.active_liter_lpm).catch(this.error);
+      { await this.setCapabilityValue('measure_water', data.active_liter_lpm).catch(this.error); }
       if (this.getCapabilityValue('meter_water') != temp_total_liter_m3)
-          await this.setCapabilityValue('meter_water', temp_total_liter_m3).catch(this.error);
+      { await this.setCapabilityValue('meter_water', temp_total_liter_m3).catch(this.error); }
       if (this.getCapabilityValue('rssi') != data.wifi_strength)
-          await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error);
+      { await this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error); }
 
     })
       .then(() => {
         this.setAvailable().catch(this.error);
       })
-      .catch(err => {
+      .catch((err) => {
         this.error(err);
         this.setUnavailable(err).catch(this.error);
-      })
+      });
   }
 
   // Catch offset updates
   onSettings(oldSettings, newSettings, changedKeys) {
-    this.log('Settings updated')
+    this.log('Settings updated');
     // Update display values if offset has changed
-    for (let k in changedKeys) {
-      let key = changedKeys[k]
+    for (const k in changedKeys) {
+      const key = changedKeys[k];
       if (key.slice(0, 7) === 'offset_') {
-        let cap = 'meter_' + key.slice(7)
-        let value = this.getCapabilityValue(cap)
-        let delta = newSettings[key] - oldSettings[key]
-        this.log('Updating value of', cap, 'from', value, 'to', value + delta)
+        const cap = `meter_${key.slice(7)}`;
+        const value = this.getCapabilityValue(cap);
+        const delta = newSettings[key] - oldSettings[key];
+        this.log('Updating value of', cap, 'from', value, 'to', value + delta);
         this.setCapabilityValue(cap, value + delta)
-          .catch(err => this.error(err))
+          .catch((err) => this.error(err));
       }
     }
-    //return true;
+    // return true;
   }
 
   updateValue(cap, value) {
     // add offset if defined
-    this.log('Updating value of', this.id, 'with capability', cap, 'to', value)
-    let cap_offset = cap.replace('meter', 'offset')
-    let offset = this.getSetting(cap_offset)
-    this.log(cap_offset, offset)
+    this.log('Updating value of', this.id, 'with capability', cap, 'to', value);
+    const cap_offset = cap.replace('meter', 'offset');
+    const offset = this.getSetting(cap_offset);
+    this.log(cap_offset, offset);
     if (offset != null) {
-      value += offset
+      value += offset;
     }
     this.setCapabilityValue(cap, value)
-      .catch(err => this.error(err))
+      .catch((err) => this.error(err));
   }
 
-}
+};

--- a/drivers/watermeter/driver.js
+++ b/drivers/watermeter/driver.js
@@ -15,32 +15,32 @@ module.exports = class HomeWizardEnergyWatermeterDriver extends Homey.Driver {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     const devices = [];
-    await Promise.all(Object.values(discoveryResults).map(async discoveryResult => {
+    await Promise.all(Object.values(discoveryResults).map(async (discoveryResult) => {
       try {
         const url = `http://${discoveryResult.address}:${discoveryResult.port}/api`;
         const res = await fetch(url);
-        if( !res.ok )
-          throw new Error(res.statusText);
+        if (!res.ok)
+        { throw new Error(res.statusText); }
 
         const data = await res.json();
 
-        let name = data.product_name
+        let name = data.product_name;
         if (numberOfDiscoveryResults > 1) {
-          name = `${data.product_name} (${data.serial})`
+          name = `${data.product_name} (${data.serial})`;
         }
 
         devices.push({
-          name: name,
+          name,
           data: {
             id: discoveryResult.id,
           },
-        })
-      } catch( err ) {
+        });
+      } catch (err) {
         this.error(discoveryResult.id, err);
       }
     }));
     return devices;
 
-}
+  }
 
-}
+};

--- a/drivers/wattcher/device.js
+++ b/drivers/wattcher/device.js
@@ -1,109 +1,106 @@
 'use strict';
 
 const Homey = require('homey');
-var homewizard = require('./../../includes/homewizard.js');
+const homewizard = require('../../includes/homewizard.js');
 
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('wattcher');
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('wattcher');
 
-var refreshIntervalId;
-var devices = {};
-//var temperature;
+let refreshIntervalId;
+const devices = {};
+// var temperature;
 
 class HomeWizardWattcher extends Homey.Device {
 
-	onInit() {
+  onInit() {
 
-		console.log('HomeWizard Wattcher '+this.getName() +' has been inited');
+    console.log(`HomeWizard Wattcher ${this.getName()} has been inited`);
 
-		const devices = this.homey.drivers.getDriver('wattcher').getDevices();
-		devices.forEach(function initdevice(device) {
-			console.log('add device: ' + JSON.stringify(device.getName()));
+    const devices = this.homey.drivers.getDriver('wattcher').getDevices();
+    devices.forEach((device) => {
+      console.log(`add device: ${JSON.stringify(device.getName())}`);
 
-			devices[device.getData().id] = device;
-			devices[device.getData().id].settings = device.getSettings();
-		});
+      devices[device.getData().id] = device;
+      devices[device.getData().id].settings = device.getSettings();
+    });
 
-		this.startPolling();
-	}
+    this.startPolling();
+  }
 
+  startPolling() {
 
+    // Clear interval
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+    }
 
-	startPolling() {
+    // Start polling for thermometer
+    this.refreshIntervalId = setInterval(() => {
+      console.log('--Start Wattcher Polling-- ');
 
-		// Clear interval
-		if (this.refreshIntervalId) {
-			clearInterval(this.refreshIntervalId);
-		}
+      this.getStatus();
 
-		// Start polling for thermometer
-		this.refreshIntervalId = setInterval(() => {
-			console.log("--Start Wattcher Polling-- ");
+    }, 1000 * 20);
 
-			this.getStatus();
+  }
 
-		}, 1000 * 20 );
+  async getStatus() {
+    Promise.resolve()
+      .then(async () => {
 
-	}
+        if (this.getSetting('homewizard_id') !== undefined) {
+          const homewizard_id = this.getSetting('homewizard_id');
+          const callback = await homewizard.getDeviceData(homewizard_id, 'energymeters');
 
-	async getStatus() {
-		Promise.resolve()
-		.then(async () => {
+          if (Object.keys(callback).length > 0) {
+            try {
+              // console.log('Start capturing data');
 
-				if (this.getSetting('homewizard_id') !== undefined) {
-					const homewizard_id = this.getSetting('homewizard_id');
-					const callback = await homewizard.getDeviceData(homewizard_id, 'energymeters');
-			
-					if (Object.keys(callback).length > 0) {
-						try {
-							// console.log('Start capturing data');
-	
-							const energy_current_cons = callback[0].po; // WATTS Energy used JSON $energymeters[0]['po']
-							const energy_daytotal_cons = callback[0].dayTotal; // KWH Energy used JSON $energymeters[0]['dayTotal']
-	
-							// Wattcher elec current
-							this.setCapabilityValue('measure_power', energy_current_cons).catch(this.error);
-							// Wattcher elec total day
-							this.setCapabilityValue('meter_power', energy_daytotal_cons).catch(this.error);
-	
-							//this.log('End capturing data');
-							//console.log('Wattcher usage- ' + energy_current_cons);
-							//console.log('Wattcher Daytotal- ' + energy_daytotal_cons);
-						} catch (err) {
-							console.log('ERROR Wattcher getStatus ', err);
-							this.setUnavailable();
-						}
-					}
-				} else {
-					console.log('Wattcher settings not found, stop polling set unavailable');
-					this.setUnavailable();
-					clearInterval(this.refreshIntervalId);
-			
-					// Only clear interval when the unavailable device is the only device on this driver
-					// This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
-					// In the event that a user has multiple devices with old settings, this function will get called every 10 seconds, but that should not be a problem
-				}
-		})
-		.then(() => {
-			this.setAvailable().catch(this.error);
-		})
-		.catch(err => {
-			this.error(err);
-			this.setUnavailable(err).catch(this.error);
-			clearInterval(this.refreshIntervalId);
-		});
-	}
+              const energy_current_cons = callback[0].po; // WATTS Energy used JSON $energymeters[0]['po']
+              const energy_daytotal_cons = callback[0].dayTotal; // KWH Energy used JSON $energymeters[0]['dayTotal']
 
+              // Wattcher elec current
+              this.setCapabilityValue('measure_power', energy_current_cons).catch(this.error);
+              // Wattcher elec total day
+              this.setCapabilityValue('meter_power', energy_daytotal_cons).catch(this.error);
 
-	onDeleted() {
+              // this.log('End capturing data');
+              // console.log('Wattcher usage- ' + energy_current_cons);
+              // console.log('Wattcher Daytotal- ' + energy_daytotal_cons);
+            } catch (err) {
+              console.log('ERROR Wattcher getStatus ', err);
+              this.setUnavailable();
+            }
+          }
+        } else {
+          console.log('Wattcher settings not found, stop polling set unavailable');
+          this.setUnavailable();
+          clearInterval(this.refreshIntervalId);
 
-		if (Object.keys(devices).length === 0) {
-			clearInterval(this.refreshIntervalId);
-			console.log("--Stopped Polling--");
-		}
+          // Only clear interval when the unavailable device is the only device on this driver
+          // This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
+          // In the event that a user has multiple devices with old settings, this function will get called every 10 seconds, but that should not be a problem
+        }
+      })
+      .then(() => {
+        this.setAvailable().catch(this.error);
+      })
+      .catch((err) => {
+        this.error(err);
+        this.setUnavailable(err).catch(this.error);
+        clearInterval(this.refreshIntervalId);
+      });
+  }
 
-		console.log('deleted: ' + JSON.stringify(this));
-	}
+  onDeleted() {
+
+    if (Object.keys(devices).length === 0) {
+      clearInterval(this.refreshIntervalId);
+      console.log('--Stopped Polling--');
+    }
+
+    console.log(`deleted: ${JSON.stringify(this)}`);
+  }
 
 }
 

--- a/drivers/wattcher/driver.js
+++ b/drivers/wattcher/driver.js
@@ -2,81 +2,82 @@
 
 const Homey = require('homey');
 
-//const request = require('request');
+// const request = require('request');
 
-//const { ManagerDrivers } = require('homey');
-//const driver = ManagerDrivers.getDriver('homewizard');
-var devices = {};
-var homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
+// const { ManagerDrivers } = require('homey');
+// const driver = ManagerDrivers.getDriver('homewizard');
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let homewizard_devices;
 
 class HomeWizardWattcher extends Homey.Driver {
 
-    onInit() {
-        console.log('HomeWizard Wattcher has been inited');
-    }
+  onInit() {
+    console.log('HomeWizard Wattcher has been inited');
+  }
 
-    async onPair(socket) {
+  async onPair(socket) {
 
-        // Show a specific view by ID
-        await socket.showView('start');
+    // Show a specific view by ID
+    await socket.showView('start');
 
-        // Show the next view
-        await socket.nextView();
+    // Show the next view
+    await socket.nextView();
 
-        // Show the previous view
-        await socket.prevView();
+    // Show the previous view
+    await socket.prevView();
 
-        // Close the pair session
-        await socket.done();
+    // Close the pair session
+    await socket.done();
 
-        // Received when a view has changed
-        socket.setHandler('showView', (viewId) => {
-          console.log('View: ' + viewId);
-          this.log("data", viewId);
+    // Received when a view has changed
+    socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      this.log('data', viewId);
+    });
+
+    socket.setHandler('get_homewizards', () => {
+      homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
+      // socket.on('get_homewizards', function () {
+
+      // homewizard_devices = driver.getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          hw_devices[key] = homewizard_devices[key];
         });
 
-        socket.setHandler('get_homewizards', () => {
-            homewizard_devices = this.homey.drivers.getDriver('homewizard').getDevices();
-        //socket.on('get_homewizards', function () {
+        console.log(hw_devices);
+        socket.emit('hw_devices', hw_devices);
 
-            //homewizard_devices = driver.getDevices();
+      });
+    });
 
-            homewizard.getDevices(function (homewizard_devices) {
-                var hw_devices = {};
+    socket.setHandler('manual_add', (device) => {
 
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    hw_devices[key] = homewizard_devices[key];
-                });
+      if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`Wattcher added ${device.data.id}`);
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+        };
+        socket.emit('success', device);
+        return devices;
 
-                console.log(hw_devices);
-                socket.emit('hw_devices', hw_devices);
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
 
-            });
-        });
+    });
 
-        socket.setHandler('manual_add', function (device) {
-
-            if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('Wattcher added ' + device.data.id);
-                devices[device.data.id] = {
-                    id: device.data.id,
-                    name: device.name,
-                    settings: device.settings,
-                };
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
-            }
-        });
-
-        socket.setHandler('disconnect', () => {
-            console.log("User aborted pairing, or pairing is finished");
-        });
-    }
+    socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+  }
 }
 
 module.exports = HomeWizardWattcher;

--- a/drivers/windmeter/driver.js
+++ b/drivers/windmeter/driver.js
@@ -21,6 +21,7 @@ class HomeWizardWindmeter extends Homey.Driver {
     // Show the next view
     socket.nextView();
 
+
     // Show the previous view
     socket.prevView();
 

--- a/drivers/windmeter/driver.js
+++ b/drivers/windmeter/driver.js
@@ -2,75 +2,76 @@
 
 const Homey = require('homey');
 
-var devices = {};
-const homewizard = require('./../../includes/homewizard.js');
-var homewizard_devices;
+const devices = {};
+const homewizard = require('../../includes/homewizard.js');
+
+let homewizard_devices;
 
 class HomeWizardWindmeter extends Homey.Driver {
 
-    onInit() {
-        console.log('HomeWizard Windmeter has been inited');
-    }
+  onInit() {
+    console.log('HomeWizard Windmeter has been inited');
+  }
 
-    onPair(socket) {
+  onPair(socket) {
 
-        // Show a specific view by ID
-        socket.showView('start');
+    // Show a specific view by ID
+    socket.showView('start');
 
-        // Show the next view
-        socket.nextView();
+    // Show the next view
+    socket.nextView();
 
-        // Show the previous view
-        socket.prevView();
+    // Show the previous view
+    socket.prevView();
 
-        // Close the pair session
-        socket.done();
+    // Close the pair session
+    socket.done();
 
-        // Received when a view has changed
-        socket.setHandler('showView', function (viewId) {
-          console.log('View: ' + viewId);
-          //this.log("data", viewId);
+    // Received when a view has changed
+    socket.setHandler('showView', (viewId) => {
+      console.log(`View: ${viewId}`);
+      // this.log("data", viewId);
+    });
+
+    socket.setHandler('get_homewizards', () => {
+      // const devices = this.homey.drivers.getDriver('homewizard').getDevices(); eslint
+      this.homey.drivers.getDriver('homewizard').getDevices();
+
+      homewizard.getDevices((homewizard_devices) => {
+        const hw_devices = {};
+
+        Object.keys(homewizard_devices).forEach((key) => {
+          hw_devices[key] = homewizard_devices[key];
         });
 
-        socket.setHandler('get_homewizards', () => {
-            // const devices = this.homey.drivers.getDriver('homewizard').getDevices(); eslint
-            this.homey.drivers.getDriver('homewizard').getDevices();
+        console.log(hw_devices);
+        socket.emit('hw_devices', hw_devices);
 
-            homewizard.getDevices(function (homewizard_devices) {
-                let hw_devices = {};
+      });
+    });
 
-                Object.keys(homewizard_devices).forEach(function (key) {
-                    hw_devices[key] = homewizard_devices[key];
-                });
+    socket.setHandler('manual_add', (device) => {
 
-                console.log(hw_devices);
-                socket.emit('hw_devices', hw_devices);
+      if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
+        // true
+        console.log(`Windmeter added ${device.data.id}`);
+        devices[device.data.id] = {
+          id: device.data.id,
+          name: device.name,
+          settings: device.settings,
+        };
+        socket.emit('success', device);
+        return devices;
 
-            });
-        });
+      }
+      socket.emit('error', 'No valid HomeWizard found, re-pair if problem persists');
 
-        socket.setHandler('manual_add', function (device) {
+    });
 
-            if (device.settings.homewizard_id.indexOf('HW_') === -1 && device.settings.homewizard_id.indexOf('HW') === 0) {
-                //true
-                console.log('Windmeter added ' + device.data.id);
-                devices[device.data.id] = {
-                    id: device.data.id,
-                    name: device.name,
-                    settings: device.settings,
-                };
-                socket.emit("success", device);
-                return devices;
-
-            } else {
-                socket.emit("error", "No valid HomeWizard found, re-pair if problem persists");
-            }
-        });
-
-        socket.setHandler('disconnect', function () {
-            console.log("User aborted pairing, or pairing is finished");
-        });
-    }
+    socket.setHandler('disconnect', () => {
+      console.log('User aborted pairing, or pairing is finished');
+    });
+  }
 
 }
 

--- a/drivers/windmeter/driver.js
+++ b/drivers/windmeter/driver.js
@@ -21,12 +21,14 @@ class HomeWizardWindmeter extends Homey.Driver {
     // Show the next view
     socket.nextView();
 
-
     // Show the previous view
     socket.prevView();
 
     // Close the pair session
     socket.done();
+    
+    
+    
 
     // Received when a view has changed
     socket.setHandler('showView', (viewId) => {

--- a/drivers/windmeter/driver.js
+++ b/drivers/windmeter/driver.js
@@ -26,9 +26,6 @@ class HomeWizardWindmeter extends Homey.Driver {
 
     // Close the pair session
     socket.done();
-    
-    
-    
 
     // Received when a view has changed
     socket.setHandler('showView', (viewId) => {

--- a/includes/homewizard.js
+++ b/includes/homewizard.js
@@ -3,39 +3,39 @@
 const fetch = require('node-fetch');
 const Homey = require('homey');
 const AbortController = require('abort-controller');
+
 const cache = {}; // Cache object to store the callnew responses
 
 const Homey2023 = Homey.platform === 'local' && Homey.platformVersion === 2;
 
+module.exports = (function() {
+  const homewizard = {};
+  const self = {};
+  self.devices = [];
+  self.polls = [];
+  const debug = false;
 
-module.exports = (function(){
-   var homewizard = {};
-   var self = {};
-   self.devices = [];
-   self.polls = [];
-   const debug = false;
+  homewizard.setDevices = function(devices) {
+    self.devices = devices;
+  };
 
-   homewizard.setDevices = function(devices){
-     self.devices = devices;
-   };
+  homewizard.getRandom = function(min, max) {
+    return Math.random() * (max - min) + min;
+  };
 
-   homewizard.getRandom = function(min, max) {
-      return Math.random() * (max - min) + min;
-   };
+  homewizard.getDevices = function(callback) {
+    callback(self.devices);
+  };
 
-   homewizard.getDevices = function(callback) {
-      callback(self.devices);
-   };
-
-   homewizard.getDeviceData = function(device_id, data_part) {
+  homewizard.getDeviceData = function(device_id, data_part) {
     return new Promise((resolve, reject) => {
       if (
-        typeof self.devices[device_id] === 'undefined' ||
-        typeof self.devices[device_id].polldata === 'undefined' ||
-        typeof self.devices[device_id].polldata[data_part] === 'undefined' ||
-        typeof self.devices[device_id] === undefined ||
-        typeof self.devices[device_id].polldata === undefined || 
-        typeof self.devices[device_id].polldata[data_part] === undefined
+        typeof self.devices[device_id] === 'undefined'
+        || typeof self.devices[device_id].polldata === 'undefined'
+        || typeof self.devices[device_id].polldata[data_part] === 'undefined'
+        || typeof self.devices[device_id] === undefined
+        || typeof self.devices[device_id].polldata === undefined
+        || typeof self.devices[device_id].polldata[data_part] === undefined
       ) {
         resolve([]);
       } else {
@@ -43,172 +43,166 @@ module.exports = (function(){
       }
     });
   };
-  
 
+  homewizard.callnew = async function(device_id, uri_part, callback) {
+    const cacheKey = `${device_id}${uri_part}`;
+    const cachedResponse = cache[cacheKey]; // Check if cached response exists
+    const currentTime = Date.now();
+    const timeoutDuration = 18000; // Timeout duration in milliseconds
 
-    homewizard.callnew = async function (device_id, uri_part, callback) {
-      const cacheKey = `${device_id}${uri_part}`;
-      const cachedResponse = cache[cacheKey]; // Check if cached response exists
-      const currentTime = Date.now();
-      const timeoutDuration = 18000; // Timeout duration in milliseconds
-    
-      if (cachedResponse && currentTime - cachedResponse.timestamp < 20000) {
-        if (debug) { console.log('Using cached response for device:', device_id, 'endpoint:', uri_part); }
-        callback(null, cachedResponse.response); // Use the cached response
-        return; // Return early
+    if (cachedResponse && currentTime - cachedResponse.timestamp < 20000) {
+      if (debug) { console.log('Using cached response for device:', device_id, 'endpoint:', uri_part); }
+      callback(null, cachedResponse.response); // Use the cached response
+      return; // Return early
+    }
+
+    try {
+      if (debug) {
+        console.log('Call device ', device_id, 'endpoint:', uri_part);
       }
-    
-      try {
-        if (debug) {
-          console.log('Call device ', device_id, 'endpoint:', uri_part);
-        }
-        if (
-          typeof self.devices[device_id] !== 'undefined' &&
-          "settings" in self.devices[device_id] &&
-          "homewizard_ip" in self.devices[device_id].settings &&
-          "homewizard_pass" in self.devices[device_id].settings
-        ) {
-          const homewizard_ip = self.devices[device_id].settings.homewizard_ip;
-          const homewizard_pass = self.devices[device_id].settings.homewizard_pass;
-    
-          const controller = new AbortController(); // Create an AbortController
-          const signal = controller.signal; // Get the AbortSignal from the controller
-    
-          // Set a timeout to abort the fetch request
-          const timeout = setTimeout(() => {
-            controller.abort(); // Abort the fetch request
-            console.log('Fetch request timed out');
-          }, timeoutDuration);
-    
-          const response = await fetch('http://' + homewizard_ip + '/' + homewizard_pass + uri_part, { signal, follow : 0, redirect: 'error' });
-    
-          clearTimeout(timeout); // Clear the timeout since the fetch request completed
-    
-          if (response.status === 200) {
-            const jsonData = await response.json();
-            if (
-              jsonData.status !== undefined &&
-              jsonData.status === 'ok'
-            ) {
-              if (typeof callback === 'function') {
-                // Cache the response with timestamp
-                cache[cacheKey] = {
-                  response: jsonData.response,
-                  timestamp: currentTime
-                };
-    
-                callback(null, jsonData.response);
-              } else {
-                console.log('Not typeof function');
-              }
+      if (
+        typeof self.devices[device_id] !== 'undefined'
+          && 'settings' in self.devices[device_id]
+          && 'homewizard_ip' in self.devices[device_id].settings
+          && 'homewizard_pass' in self.devices[device_id].settings
+      ) {
+        const { homewizard_ip } = self.devices[device_id].settings;
+        const { homewizard_pass } = self.devices[device_id].settings;
+
+        const controller = new AbortController(); // Create an AbortController
+        const { signal } = controller; // Get the AbortSignal from the controller
+
+        // Set a timeout to abort the fetch request
+        const timeout = setTimeout(() => {
+          controller.abort(); // Abort the fetch request
+          console.log('Fetch request timed out');
+        }, timeoutDuration);
+
+        const response = await fetch(`http://${homewizard_ip}/${homewizard_pass}${uri_part}`, { signal, follow: 0, redirect: 'error' });
+
+        clearTimeout(timeout); // Clear the timeout since the fetch request completed
+
+        if (response.status === 200) {
+          const jsonData = await response.json();
+          if (
+            jsonData.status !== undefined
+              && jsonData.status === 'ok'
+          ) {
+            if (typeof callback === 'function') {
+              // Cache the response with timestamp
+              cache[cacheKey] = {
+                response: jsonData.response,
+                timestamp: currentTime,
+              };
+
+              callback(null, jsonData.response);
             } else {
-              console.log('jsonData.status not ok');
-              callback('Invalid data', []);
+              console.log('Not typeof function');
             }
           } else {
-            console.log('Error: no clue what is going on here.');
-            callback('Error', []);
+            console.log('jsonData.status not ok');
+            callback('Invalid data', []);
           }
         } else {
-          console.log('Homewizard ' + device_id + ': settings not found!');
+          console.log('Error: no clue what is going on here.');
+          callback('Error', []);
         }
-      } catch (error) {
-        if (error.name === 'AbortError') {
-          console.log('Fetch request aborted');
-          return; // Return early if fetch request was aborted
-        }
-        if (error.code === 'ECONNRESET') {
-          console.log('Connection was reset');
-        }
-        console.error('FETCH PROBLEM -> ' + error);
+      } else {
+        console.log(`Homewizard ${device_id}: settings not found!`);
       }
-    };
-
-
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        console.log('Fetch request aborted');
+        return; // Return early if fetch request was aborted
+      }
+      if (error.code === 'ECONNRESET') {
+        console.log('Connection was reset');
+      }
+      console.error(`FETCH PROBLEM -> ${error}`);
+    }
+  };
 
   if (!Homey2023) {
-   homewizard.ledring_pulse = function(device_id, colorName) {
-     var homewizard_ledring =  self.devices[device_id].settings.homewizard_ledring;
-     if (homewizard_ledring) {
-       Homey.manager('ledring').animate(
-           'pulse', // animation name (choose from loading, pulse, progress, solid)
-           {
-               color: colorName,
-           },
-           'INFORMATIVE', // priority
-           3000, // duration
-           function(err) { // callback
-               if(err) return Homey.error(err);
-               console.log("Ledring pulsing "+colorName);
-           }
-       );
-     }
+    homewizard.ledring_pulse = function(device_id, colorName) {
+      const { homewizard_ledring } = self.devices[device_id].settings;
+      if (homewizard_ledring) {
+        Homey.manager('ledring').animate(
+          'pulse', // animation name (choose from loading, pulse, progress, solid)
+          {
+            color: colorName,
+          },
+          'INFORMATIVE', // priority
+          3000, // duration
+          (err) => { // callback
+            if (err) return Homey.error(err);
+            console.log(`Ledring pulsing ${colorName}`);
+          },
+        );
+      }
+    };
+  }
+
+  homewizard.startpoll = function() {
+    homewizard.poll(); // Initial poll
+
+    self.polls.device_id = setInterval(async () => {
+      try {
+        await homewizard.poll();
+      } catch (error) {
+        console.error('Error occurred during polling:', error);
+      }
+    }, 1000 * 20);
   };
-};
 
-homewizard.startpoll = function() {
-   homewizard.poll(); // Initial poll
- 
-   self.polls.device_id = setInterval(async function() {
-     try {
-       await homewizard.poll();
-     } catch (error) {
-       console.error('Error occurred during polling:', error);
-     }
-   }, 1000 * 20);
- };
+  homewizard.poll = async function() {
+    for (const device_id in self.devices) {
+      if (
+        typeof self.devices[device_id].polldata === 'undefined'
+          || typeof self.devices[device_id].polldata == 'undefined'
+          || typeof self.devices[device_id].polldata == undefined
+      ) {
+        self.devices[device_id].polldata = [];
+      }
 
-  
-   homewizard.poll = async function() {
-      for (const device_id in self.devices) {
-        if (
-          typeof self.devices[device_id].polldata === 'undefined' ||
-          typeof self.devices[device_id].polldata == 'undefined' ||
-          typeof self.devices[device_id].polldata == undefined
-        ) {
-          self.devices[device_id].polldata = [];
-        }
-    
-        const response = await new Promise((resolve, reject) => {
-          homewizard.callnew(device_id, '/get-sensors', (err, response) => {
-            if (err === null || err == null) {
-              resolve(response);
-            } else {
-              reject(err);
-            }
-          });
+      const response = await new Promise((resolve, reject) => {
+        homewizard.callnew(device_id, '/get-sensors', (err, response) => {
+          if (err === null || err == null) {
+            resolve(response);
+          } else {
+            reject(err);
+          }
         });
-    
-        if (response) {
-          self.devices[device_id].polldata.preset = response.preset;
-          self.devices[device_id].polldata.heatlinks = response.heatlinks;
-          self.devices[device_id].polldata.energylinks = response.energylinks;
-          self.devices[device_id].polldata.energymeters = response.energymeters;
-          self.devices[device_id].polldata.thermometers = response.thermometers;
-          self.devices[device_id].polldata.rainmeters = response.rainmeters;
-          self.devices[device_id].polldata.windmeters = response.windmeters;
-          self.devices[device_id].polldata.kakusensors = response.kakusensors;
-    
-          if (Object.keys(response.energylinks).length !== 0) {
-            const response2 = await new Promise((resolve, reject) => {
-              new Promise((resolve) => setTimeout(resolve, 1000));
-              homewizard.callnew(device_id, '/el/get/0/readings', (err2, response2) => {
-                if (err2 === null || err2 == null) {
-                  //self.devices[device_id].polldata.energylink_el = response2;
-                  resolve(response2);
-                } else {
-                  reject(err2);
-                }
-              });
+      });
+
+      if (response) {
+        self.devices[device_id].polldata.preset = response.preset;
+        self.devices[device_id].polldata.heatlinks = response.heatlinks;
+        self.devices[device_id].polldata.energylinks = response.energylinks;
+        self.devices[device_id].polldata.energymeters = response.energymeters;
+        self.devices[device_id].polldata.thermometers = response.thermometers;
+        self.devices[device_id].polldata.rainmeters = response.rainmeters;
+        self.devices[device_id].polldata.windmeters = response.windmeters;
+        self.devices[device_id].polldata.kakusensors = response.kakusensors;
+
+        if (Object.keys(response.energylinks).length !== 0) {
+          const response2 = await new Promise((resolve, reject) => {
+            new Promise((resolve) => setTimeout(resolve, 1000));
+            homewizard.callnew(device_id, '/el/get/0/readings', (err2, response2) => {
+              if (err2 === null || err2 == null) {
+                // self.devices[device_id].polldata.energylink_el = response2;
+                resolve(response2);
+              } else {
+                reject(err2);
+              }
             });
-            if (response2) {
-              self.devices[device_id].polldata.energylink_el = response2;
-            }
+          });
+          if (response2) {
+            self.devices[device_id].polldata.energylink_el = response2;
           }
         }
       }
-    };
-    
+    }
+  };
 
-   return homewizard;
-})();
+  return homewizard;
+}());

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,143 @@
         "npm": "^10.8.3"
       },
       "devDependencies": {
-        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.3"
+        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.3",
+        "eslint": "^8.57.0",
+        "eslint-config-athom": "^3.1.5"
       }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.1",
+      "resolved": "https://npm.dev.homewizard.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://npm.dev.homewizard.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://npm.dev.homewizard.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://npm.dev.homewizard.com/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://npm.dev.homewizard.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://npm.dev.homewizard.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "dev": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://npm.dev.homewizard.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://npm.dev.homewizard.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://npm.dev.homewizard.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true
     },
     "node_modules/@types/homey": {
       "name": "homey-apps-sdk-v3-types",
@@ -27,10 +162,248 @@
         "@types/node": "^14.14.20"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://npm.dev.homewizard.com/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://npm.dev.homewizard.com/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://npm.dev.homewizard.com/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://npm.dev.homewizard.com/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://npm.dev.homewizard.com/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://npm.dev.homewizard.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://npm.dev.homewizard.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
     },
     "node_modules/abort-controller": {
@@ -44,6 +417,1051 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://npm.dev.homewizard.com/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://npm.dev.homewizard.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://npm.dev.homewizard.com/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://npm.dev.homewizard.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://npm.dev.homewizard.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://npm.dev.homewizard.com/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.8",
+      "resolved": "https://npm.dev.homewizard.com/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://npm.dev.homewizard.com/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.5",
+      "resolved": "https://npm.dev.homewizard.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://npm.dev.homewizard.com/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://npm.dev.homewizard.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://npm.dev.homewizard.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://npm.dev.homewizard.com/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://npm.dev.homewizard.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://npm.dev.homewizard.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://npm.dev.homewizard.com/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://npm.dev.homewizard.com/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://npm.dev.homewizard.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://npm.dev.homewizard.com/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://npm.dev.homewizard.com/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://npm.dev.homewizard.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://npm.dev.homewizard.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://npm.dev.homewizard.com/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://npm.dev.homewizard.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://npm.dev.homewizard.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://npm.dev.homewizard.com/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://npm.dev.homewizard.com/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://npm.dev.homewizard.com/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://npm.dev.homewizard.com/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://npm.dev.homewizard.com/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://npm.dev.homewizard.com/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.23.9",
+      "resolved": "https://npm.dev.homewizard.com/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://npm.dev.homewizard.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://npm.dev.homewizard.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://npm.dev.homewizard.com/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://npm.dev.homewizard.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://npm.dev.homewizard.com/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-athom": {
+      "version": "3.1.5",
+      "resolved": "https://npm.dev.homewizard.com/eslint-config-athom/-/eslint-config-athom-3.1.5.tgz",
+      "integrity": "sha512-QPseQu6fwQph9BtRwints6+3d+e7T7SvD26ColkAh/N0NQEJfamMd4gg7qm8gHQFDQy85hKQi0JRwJD/wKpYUA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.13.1",
+        "@typescript-eslint/parser": "^6.13.1",
+        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-plugin-homey-app": "^1.0.2",
+        "eslint-plugin-import": "^2.24.2",
+        "eslint-plugin-mocha": "^6.3.0",
+        "eslint-plugin-node": "^11.1.0",
+        "typescript": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.5.0"
+      }
+    },
+    "node_modules/eslint-config-athom/node_modules/eslint-config-airbnb-base": {
+      "version": "14.2.1",
+      "resolved": "https://npm.dev.homewizard.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+      "dev": true,
+      "dependencies": {
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
+        "eslint-plugin-import": "^2.22.1"
+      }
+    },
+    "node_modules/eslint-config-athom/node_modules/eslint-plugin-homey-app": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/eslint-plugin-homey-app/-/eslint-plugin-homey-app-1.0.2.tgz",
+      "integrity": "sha512-uO09MpI0GaRfxWd8jKf6ei71zCCx3C4/8m1vm/GqYv1y/TEi8i2GdIlBCqyN67IXd4fwT+BNd+BoGxKh+8WC8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": "^7.32.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://npm.dev.homewizard.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://npm.dev.homewizard.com/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.0",
+      "resolved": "https://npm.dev.homewizard.com/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://npm.dev.homewizard.com/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://npm.dev.homewizard.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.31.0",
+      "resolved": "https://npm.dev.homewizard.com/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "dev": true,
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://npm.dev.homewizard.com/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://npm.dev.homewizard.com/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://npm.dev.homewizard.com/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "6.3.0",
+      "resolved": "https://npm.dev.homewizard.com/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
+      "integrity": "sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "ramda": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://npm.dev.homewizard.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://npm.dev.homewizard.com/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://npm.dev.homewizard.com/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://npm.dev.homewizard.com/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://npm.dev.homewizard.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://npm.dev.homewizard.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://npm.dev.homewizard.com/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://npm.dev.homewizard.com/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://npm.dev.homewizard.com/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://npm.dev.homewizard.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://npm.dev.homewizard.com/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -51,6 +1469,1010 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://npm.dev.homewizard.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://npm.dev.homewizard.com/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://npm.dev.homewizard.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://npm.dev.homewizard.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://npm.dev.homewizard.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://npm.dev.homewizard.com/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://npm.dev.homewizard.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://npm.dev.homewizard.com/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://npm.dev.homewizard.com/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://npm.dev.homewizard.com/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://npm.dev.homewizard.com/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://npm.dev.homewizard.com/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://npm.dev.homewizard.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://npm.dev.homewizard.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://npm.dev.homewizard.com/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://npm.dev.homewizard.com/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://npm.dev.homewizard.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://npm.dev.homewizard.com/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://npm.dev.homewizard.com/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://npm.dev.homewizard.com/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://npm.dev.homewizard.com/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://npm.dev.homewizard.com/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://npm.dev.homewizard.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://npm.dev.homewizard.com/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://npm.dev.homewizard.com/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://npm.dev.homewizard.com/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://npm.dev.homewizard.com/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://npm.dev.homewizard.com/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://npm.dev.homewizard.com/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://npm.dev.homewizard.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://npm.dev.homewizard.com/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://npm.dev.homewizard.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://npm.dev.homewizard.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://npm.dev.homewizard.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://npm.dev.homewizard.com/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://npm.dev.homewizard.com/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://npm.dev.homewizard.com/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://npm.dev.homewizard.com/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://npm.dev.homewizard.com/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://npm.dev.homewizard.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://npm.dev.homewizard.com/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://npm.dev.homewizard.com/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://npm.dev.homewizard.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://npm.dev.homewizard.com/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://npm.dev.homewizard.com/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://npm.dev.homewizard.com/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://npm.dev.homewizard.com/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://npm.dev.homewizard.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://npm.dev.homewizard.com/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://npm.dev.homewizard.com/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://npm.dev.homewizard.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://npm.dev.homewizard.com/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://npm.dev.homewizard.com/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://npm.dev.homewizard.com/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://npm.dev.homewizard.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://npm.dev.homewizard.com/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://npm.dev.homewizard.com/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://npm.dev.homewizard.com/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://npm.dev.homewizard.com/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://npm.dev.homewizard.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://npm.dev.homewizard.com/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -2404,10 +4826,943 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://npm.dev.homewizard.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://npm.dev.homewizard.com/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.8",
+      "resolved": "https://npm.dev.homewizard.com/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://npm.dev.homewizard.com/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://npm.dev.homewizard.com/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://npm.dev.homewizard.com/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://npm.dev.homewizard.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://npm.dev.homewizard.com/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://npm.dev.homewizard.com/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://npm.dev.homewizard.com/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://npm.dev.homewizard.com/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://npm.dev.homewizard.com/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://npm.dev.homewizard.com/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://npm.dev.homewizard.com/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://npm.dev.homewizard.com/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://npm.dev.homewizard.com/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://npm.dev.homewizard.com/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://npm.dev.homewizard.com/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ramda": {
+      "version": "0.27.2",
+      "resolved": "https://npm.dev.homewizard.com/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "dev": true
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://npm.dev.homewizard.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://npm.dev.homewizard.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://npm.dev.homewizard.com/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://npm.dev.homewizard.com/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://npm.dev.homewizard.com/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://npm.dev.homewizard.com/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://npm.dev.homewizard.com/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://npm.dev.homewizard.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://npm.dev.homewizard.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://npm.dev.homewizard.com/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://npm.dev.homewizard.com/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://npm.dev.homewizard.com/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://npm.dev.homewizard.com/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://npm.dev.homewizard.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://npm.dev.homewizard.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://npm.dev.homewizard.com/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://npm.dev.homewizard.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://npm.dev.homewizard.com/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://npm.dev.homewizard.com/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://npm.dev.homewizard.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://npm.dev.homewizard.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://npm.dev.homewizard.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://npm.dev.homewizard.com/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://npm.dev.homewizard.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://npm.dev.homewizard.com/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://npm.dev.homewizard.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://npm.dev.homewizard.com/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://npm.dev.homewizard.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://npm.dev.homewizard.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://npm.dev.homewizard.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://npm.dev.homewizard.com/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://npm.dev.homewizard.com/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://npm.dev.homewizard.com/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://npm.dev.homewizard.com/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://npm.dev.homewizard.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://npm.dev.homewizard.com/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://npm.dev.homewizard.com/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://npm.dev.homewizard.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://npm.dev.homewizard.com/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -2421,6 +5776,133 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://npm.dev.homewizard.com/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://npm.dev.homewizard.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://npm.dev.homewizard.com/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://npm.dev.homewizard.com/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://npm.dev.homewizard.com/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://npm.dev.homewizard.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://npm.dev.homewizard.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "athom app run",
-    "lint": "eslint . --ext js,ts,tsx --report-unused-disable-directives --max-warnings 0 --fix"
+    "lint": "eslint . --ext js,ts,tsx --report-unused-disable-directives --max-warnings 0 --fix",
+    "lint-check": "eslint . --ext js,ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "npm": "^10.8.3"
   },
   "scripts": {
-    "test": "athom app run"
+    "test": "athom app run",
+    "lint": "eslint . --ext js,ts,tsx --report-unused-disable-directives --max-warnings 0 --fix"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,8 @@
   },
   "homepage": "https://github.com/jtebbens/com.homewizard#readme",
   "devDependencies": {
-    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.3"
+    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.3",
+    "eslint": "^8.57.0",
+    "eslint-config-athom": "^3.1.5"
   }
 }


### PR DESCRIPTION
Continuing on https://github.com/jtebbens/com.homewizard/pull/83

You thought #110  was big.. that was nothing...:

This PR:
- Implements eslint via the default config of https://github.com/athombv/eslint-config-athom
- Removes prettier (as this has conflicting rules, and was not used in CI)
- Adds a pre-commit-config file; Install pre-commit, and run `pre-commit install`. This runs some quick checks before each commit to prevent 'invalid' commits. Can be ignored via `--no-check` flag per commit or even not installed at all.

Real changes:
- package.json has a new 'scripts' to run eslint + addition of devDependencies
- Addition of pre-commit-config.yaml
- Updated eslintrc.json to use athoms style settings
- Updated validate.json to validate the change for each PR

The rest are auto-updated via eslint.

All non auto-fixable rules are disabled in `eslintrc.json`, and can be enabled step by step. 