### PR TITLE
Clean up capabilities and data processing for v2 devices

### DIFF
--- a/drivers/energy_v2/device.js
+++ b/drivers/energy_v2/device.js
@@ -163,7 +163,7 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
       setCapabilityPromises.push(this._setCapabilityValue('measure_power.l3', data.power_l3_w).catch(this.error));
 
       /// / Tariff
-      setCapabilityPromises.push(this._setCapabilityValue('tariff', data.tariff).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('tariff', data.active_tariff).catch(this.error));
 
       /// / Total consumption
       setCapabilityPromises.push(this._setCapabilityValue('meter_power.consumed', data.energy_import_kwh).catch(this.error));
@@ -209,7 +209,7 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
       setCapabilityPromises.push(this._setCapabilityValue('measure_power.montly_power_peak', data.montly_power_peak_w).catch(this.error));
 
       // Trigger flows
-      triggerFlowPromises.push(this._triggerFlowOnChange('tariff_changed', data.tariff).catch(this.error));
+      triggerFlowPromises.push(this._triggerFlowOnChange('tariff_changed', data.active_tariff).catch(this.error));
       triggerFlowPromises.push(this._triggerFlowOnChange('import_changed', data.energy_import_kwh).catch(this.error));
       triggerFlowPromises.push(this._triggerFlowOnChange('export_changed', data.energy_export_kwh).catch(this.error));
 

--- a/drivers/energy_v2/device.js
+++ b/drivers/energy_v2/device.js
@@ -8,29 +8,13 @@ const POLL_INTERVAL = 1000 * 10; // 10 seconds
 module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
 
   async onInit() {
+    await this._updateCapabilities();
+    await this._registerCapabilityListeners();
+
     this.onPollInterval = setInterval(this.onPoll.bind(this), POLL_INTERVAL);
-
-    this._flowTriggerTariff = this.homey.flow.getDeviceTriggerCard('tariff_changed');
-    this._flowTriggerImport = this.homey.flow.getDeviceTriggerCard('import_changed');
-    this._flowTriggerExport = this.homey.flow.getDeviceTriggerCard('export_changed');
-
     this.token = this.getStoreValue('token');
 
-    this.registerCapabilityListener('identify', async (value) => {
-      await api.identify(this.url, this.token);
-    });
-  }
-
-  flowTriggerTariff(device, tokens) {
-    this._flowTriggerTariff.trigger(device, tokens).catch(this.error);
-  }
-
-  flowTriggerImport(device, tokens) {
-    this._flowTriggerImport.trigger(device, tokens).catch(this.error);
-  }
-
-  flowTriggerExport(device, tokens) {
-    this._flowTriggerExport.trigger(device, tokens).catch(this.error);
+    this._triggerFlowPrevious = {};
   }
 
   onDeleted() {
@@ -59,6 +43,106 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
     this.onPoll();
   }
 
+  /**
+   * Helper function to update capabilities configuration.
+   * This function is called when the device is initialized.
+   */
+  async _updateCapabilities() {
+    if (!this.hasCapability('identify')) {
+      await this.addCapability('identify').catch(this.error);
+      console.log(`created capability identify for ${this.getName()}`);
+    }
+
+    // Remove capabilities that are not needed
+    if (this.hasCapability('measure_power.power_w')) {
+      await this.removeCapability('measure_power.power_w').catch(this.error);
+      console.log(`removed capability measure_power.power_w for ${this.getName()}`);
+    }
+  }
+
+  /**
+   * Helper function to register capability listeners.
+   * This function is called when the device is initialized.
+   */
+  async _registerCapabilityListeners() {
+    this.registerCapabilityListener('identify', async (value) => {
+      await api.identify(this.url, this.token);
+    });
+  }
+
+  /**
+   * Helper function for 'optional' capabilities.
+   * This function is called when the device is initialized.
+   * It will create the capability if it doesn't exist.
+   *
+   * We do not remove capabilities here, as we assume the user may want to keep them.
+   * Besides that we assume that the P1 Meter is connected to a smart meter that does not change often.
+   *
+   * @param {string} capability The capability to set
+   * @param {*} value The value to set
+   * @returns {Promise<void>} A promise that resolves when the capability is set
+   */
+  async _setCapabilityValue(capability, value) {
+    // Test if value is undefined, if so, we don't set the capability
+    if (value === undefined) {
+      return;
+    }
+
+    // Create a new capability if it doesn't exist
+    if (!this.hasCapability(capability)) {
+      await this.addCapability(capability).catch(this.error);
+    }
+
+    // Set the capability value
+    await this.setCapabilityValue(capability, value).catch(this.error);
+  }
+
+  /**
+   * Helper function to trigger flows on change.
+   * This function is called when the device is initialized.
+   *
+   * We use this function to trigger flows when the value changes.
+   * We store the previous value in a variable.
+   *
+   * @param {*} flow_id Flow ID name
+   * @param {*} value The value to check for changes
+   * @returns {Promise<void>} A promise that resolves when the flow is triggered
+   */
+  async _triggerFlowOnChange(flow_id, value) {
+
+    // Ignore if value is undefined
+    if (value === undefined) {
+      return;
+    }
+
+    // Check if the value is undefined
+    // If so, we assume this is the first time we are setting the value
+    // We cannot trust the the 'trigger' function to be called with the correct value
+    if (this._triggerFlowPrevious[flow_id] === undefined) {
+      this._triggerFlowPrevious[flow_id] = value;
+      return;
+    }
+
+    // Return of the value is the same as the previous value
+    if (this._triggerFlowPrevious[flow_id] === value) {
+
+      // We don't need to trigger the flow
+      return;
+    }
+
+    // It is a bit 'costly' to get the flow card every time
+    // But we can assume the trigger does not change often
+    const flow = this.homey.flow.getDeviceTriggerCard(flow_id);
+    if (flow === undefined) {
+      this.error('Flow not found');
+      return;
+    }
+
+    // Update value and trigger the flow
+    this._triggerFlowPrevious[flow_id] = value;
+    flow.trigger(this, { [flow_id]: value }).catch(this.error);
+  }
+
   onPoll() {
 
     // URL may be undefined if the device is not available
@@ -68,383 +152,66 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
 
       const data = await api.getMeasurement(this.url, this.token);
 
-      // Capture all await promises
-      const promises = [];
+      const setCapabilityPromises = [];
+      const triggerFlowPromises = [];
 
-      // identify
-      if (!this.hasCapability('identify')) {
-        await this.addCapability('identify').catch(this.error);
-      }
+      // Values
+      /// / Power
+      setCapabilityPromises.push(this._setCapabilityValue('measure_power', data.power_w).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_power.l1', data.power_l1_w).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_power.l2', data.power_l2_w).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_power.l3', data.power_l3_w).catch(this.error));
 
-      // Save export data check if capabilities are present first
-      if (!this.hasCapability('measure_power')) {
-        promises.push(this.addCapability('measure_power').catch(this.error));
-      }
+      /// / Tariff
+      setCapabilityPromises.push(this._setCapabilityValue('tariff', data.tariff).catch(this.error));
 
-      //      if (!this.hasCapability('measure_current.l1') && (data.current_l1_a !== undefined)) {
-      //        promises.push(this.addCapability('measure_current.l1').catch(this.error));
-      //      }
+      /// / Total consumption
+      setCapabilityPromises.push(this._setCapabilityValue('meter_power.consumed', data.energy_import_kwh).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('meter_power.consumed.t1', data.energy_import_t1_kwh).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('meter_power.consumed.t2', data.energy_import_t2_kwh).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('meter_power.consumed.t3', data.energy_import_t3_kwh).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('meter_power.consumed.t4', data.energy_import_t4_kwh).catch(this.error));
 
-      if (this.hasCapability('measure_power.power_w')) {
-        promises.push(this.removeCapability('measure_power.power_w').catch(this.error));
-      } // remove
-
-      if (!this.hasCapability('meter_power.consumed.t1')) {
-        promises.push(this.addCapability('meter_power.consumed.t1').catch(this.error));
-        promises.push(this.addCapability('meter_power.consumed.t2').catch(this.error));
-      }
-
-      if (!this.hasCapability('meter_power.consumed')) {
-        promises.push(this.addCapability('meter_power.consumed').catch(this.error));
-      }
-
-      // if (!this.hasCapability('rssi')) {
-      //  promises.push(this.addCapability('rssi').catch(this.error));
-      // }
-
-      if (!this.hasCapability('tariff')) {
-        promises.push(this.addCapability('tariff').catch(this.error));
+      /// / Total production
+      // if energy_export_kwh == 0, we assume the device does not produce energy
+      // We ignore this case
+      if (data.energy_export_kwh != 0) {
+        setCapabilityPromises.push(this._setCapabilityValue('meter_power.returned', data.energy_export_kwh).catch(this.error));
+        setCapabilityPromises.push(this._setCapabilityValue('meter_power.produced.t1', data.energy_export_t1_kwh).catch(this.error));
+        setCapabilityPromises.push(this._setCapabilityValue('meter_power.produced.t2', data.energy_export_t2_kwh).catch(this.error));
+        setCapabilityPromises.push(this._setCapabilityValue('meter_power.produced.t3', data.energy_export_t3_kwh).catch(this.error));
+        setCapabilityPromises.push(this._setCapabilityValue('meter_power.produced.t4', data.energy_export_t4_kwh).catch(this.error));
       }
 
-      // Update values
-      if (this.getCapabilityValue('measure_power') != data.power_w)
-      { promises.push(this.setCapabilityValue('measure_power', data.power_w).catch(this.error)); }
-      // if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-      // promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error));
-      if (this.getCapabilityValue('meter_power.consumed.t1') != data.energy_import_t1_kwh)
-      { promises.push(this.setCapabilityValue('meter_power.consumed.t1', data.energy_import_t1_kwh).catch(this.error)); }
-      if (this.getCapabilityValue('meter_power.consumed.t2') != data.energy_import_t2_kwh)
-      { promises.push(this.setCapabilityValue('meter_power.consumed.t2', data.energy_import_t2_kwh).catch(this.error)); }
-      // if (this.getCapabilityValue('rssi') != data.wifi_strength)
-      // promises.push(this.setCapabilityValue('rssi', data.wifi_strength).catch(this.error));
-      if (this.getCapabilityValue('tariff') != data.tariff)
-      { promises.push(this.setCapabilityValue('tariff', data.tariff).catch(this.error)); }
-      if (this.getCapabilityValue('meter_power.consumed') != data.energy_import_kwh)
-      { promises.push(this.setCapabilityValue('meter_power.consumed', data.energy_import_kwh).catch(this.error)); }
+      /// / Voltage
+      setCapabilityPromises.push(this._setCapabilityValue('measure_voltage.l1', data.voltage_l1_v).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_voltage.l2', data.voltage_l2_v).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_voltage.l3', data.voltage_l3_v).catch(this.error));
 
-      // Trigger tariff
-      if (data.tariff != this.getStoreValue('last_tariff')) {
-        this.flowTriggerTariff(this, { tariff_changed: data.tariff });
-        this.setStoreValue('last_tariff', data.tariff).catch(this.error);
-      }
+      /// / Current
+      setCapabilityPromises.push(this._setCapabilityValue('measure_current', data.current_l1_a).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_current.l2', data.current_l2_a).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('measure_current.l3', data.current_l3_a).catch(this.error));
 
-      if (data.current_l1_a !== undefined) {
-        if (!this.hasCapability('measure_current.l1')) {
-          promises.push(this.addCapability('measure_current.l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-        { promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error)); }
-      }
-      else if (data.current_l1_a == null) {
-        // delete measure_current.l1 -> some meters dont have this property
-        promises.push(this.removeCapability('measure_current.l1').catch(this.error));
-      }
+      /// / Voltage sags and swells
+      setCapabilityPromises.push(this._setCapabilityValue('voltage_sag_l1', data.voltage_sag_l1_count).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('voltage_sag_l2', data.voltage_sag_l2_count).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('voltage_sag_l3', data.voltage_sag_l3_count).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('voltage_swell_l1', data.voltage_swell_l1_count).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('voltage_swell_l2', data.voltage_swell_l2_count).catch(this.error));
+      setCapabilityPromises.push(this._setCapabilityValue('voltage_swell_l3', data.voltage_swell_l3_count).catch(this.error));
 
-      // Not all users have a gas meter in their system (if NULL ignore creation or even delete from view)
+      /// / Power failures
+      setCapabilityPromises.push(this._setCapabilityValue('long_power_fail_count', data.long_power_fail_count).catch(this.error));
 
-      if (data.total_gas_m3 !== undefined) {
-      								if (!this.hasCapability('meter_gas')) {
-      									promises.push(this.addCapability('meter_gas').catch(this.error));
-      								}
-        if (this.getCapabilityValue('meter_gas') != data.total_gas_m3)
-        { promises.push(this.setCapabilityValue('meter_gas', data.total_gas_m3).catch(this.error)); }
-      							}
-      							else if (data.total_gas_m3 == null) {
-        // delete gas meter
-      								promises.push(this.removeCapability('meter_gas').catch(this.error));
-      }
+      /// / Belgium
+      setCapabilityPromises.push(this._setCapabilityValue('measure_power.montly_power_peak', data.montly_power_peak_w).catch(this.error));
 
-      // Check to see if there is solar panel production exported if received value is more than 1 it returned back to the power grid
-      if ((data.energy_export_t1_kwh > 1) || (data.energy_export_t2_kwh > 1)) {
-        if ((!this.hasCapability('meter_power.produced.t1')) || (!this.hasCapability('meter_power.returned'))) {
-          // add production meters
-          promises.push(this.addCapability('meter_power.produced.t1').catch(this.error));
-          promises.push(this.addCapability('meter_power.produced.t2').catch(this.error));
-          promises.push(this.addCapability('meter_power.returned').catch(this.error));
-        }
-        // update values for solar production
-        if (this.getCapabilityValue('meter_power.produced.t1') != data.energy_export_t1_kwh)
-        { promises.push(this.setCapabilityValue('meter_power.produced.t1', data.energy_export_t1_kwh).catch(this.error)); }
-        if (this.getCapabilityValue('meter_power.produced.t2') != data.energy_export_t2_kwh)
-        { promises.push(this.setCapabilityValue('meter_power.produced.t2', data.energy_export_t1_kwh).catch(this.error)); }
-      }
-      else if ((data.energy_export_t1_kwh < 1) || (data.energy_export_t2_kwh < 1)) {
-        promises.push(this.removeCapability('meter_power.produced.t1').catch(this.error));
-        promises.push(this.removeCapability('meter_power.produced.t2').catch(this.error));
-      }
-
-      // aggregated meter for Power by the hour support
-      if (!this.hasCapability('meter_power')) {
-        promises.push(this.addCapability('meter_power').catch(this.error));
-      }
-      // update calculated value which is sum of import deducted by the sum of the export this overall kwh number is used for Power by the hour app
-      // Pre P1 firmware 4.x
-      if (data.energy_import_kwh === undefined) {
-        if (this.getCapabilityValue('meter_power') != ((data.energy_import_t1_kwh + data.energy_import_t2_kwh) - (data.energy_export_t1_kwh + data.energy_export_t2_kwh)))
-        { promises.push(this.setCapabilityValue('meter_power', ((data.energy_import_t1_kwh + data.energy_import_t2_kwh) - (data.energy_export_t1_kwh + data.energy_export_t2_kwh))).catch(this.error)); }
-      }
-      // P1 Firmwmare 4.x and later
-      else if (data.energy_import_kwh !== undefined) {
-        if (this.getCapabilityValue('meter_power') != (data.energy_import_kwh - data.energy_export_kwh))
-        { promises.push(this.setCapabilityValue('meter_power', (data.energy_import_kwh - data.energy_export_kwh)).catch(this.error)); }
-        if (this.getCapabilityValue('meter_power.returned') != data.energy_export_kwh)
-        { promises.push(this.setCapabilityValue('meter_power.returned', data.energy_export_kwh).catch(this.error)); }
-      }
-
-      // Trigger import
-      if (data.energy_import_kwh != this.getStoreValue('last_total_import_kwh')) {
-        this.flowTriggerImport(this, { import_changed: data.energy_import_kwh });
-        this.setStoreValue('last_total_import_kwh', data.energy_import_kwh).catch(this.error);
-      }
-
-      // Trigger export
-      if (data.energy_export_kwh != this.getStoreValue('last_total_export_kwh')) {
-        this.flowTriggerExport(this, { export_changed: data.energy_export_kwh });
-        this.setStoreValue('last_total_export_kwh', data.energy_export_kwh).catch(this.error);
-      }
-
-      // Belgium
-      if (data.montly_power_peak_w !== undefined) {
-        if (!this.hasCapability('measure_power.montly_power_peak')) {
-          promises.push(this.addCapability('measure_power.montly_power_peak').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_power.montly_power_peak') != data.montly_power_peak_w)
-        { promises.push(this.setCapabilityValue('measure_power.montly_power_peak', data.montly_power_peak_w).catch(this.error)); }
-      }
-      else if ((data.montly_power_peak_w == undefined) && (this.hasCapability('measure_power.montly_power_peak'))) {
-        promises.push(this.removeCapability('measure_power.montly_power_peak').catch(this.error));
-      }
-
-      // voltage_l1_v Some P1 meters do have voltage data
-      if (data.voltage_l1_v !== undefined) {
-        if (!this.hasCapability('measure_voltage.l1')) {
-          promises.push(this.addCapability('measure_voltage.l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_voltage.l1') != data.voltage_l1_v)
-        { promises.push(this.setCapabilityValue('measure_voltage.l1', data.voltage_l1_v).catch(this.error)); }
-      }
-      else if ((data.voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
-        promises.push(this.removeCapability('measure_voltage.l1').catch(this.error));
-      }
-
-      // current_l1_a Some P1 meters do have amp data
-      if (data.current_l1_a !== undefined) {
-        if (!this.hasCapability('measure_current.l1')) {
-          promises.push(this.addCapability('measure_current.l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-        { promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error)); }
-      }
-      else if ((data.current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
-        promises.push(this.removeCapability('measure_current.l1').catch(this.error));
-      }
-
-      // Power failure count - long_power_fail_count
-      if (data.long_power_fail_count !== undefined) {
-        if (!this.hasCapability('long_power_fail_count')) {
-          promises.push(this.addCapability('long_power_fail_count').catch(this.error));
-        }
-        if (this.getCapabilityValue('long_power_fail_count') != data.long_power_fail_count)
-        { promises.push(this.setCapabilityValue('long_power_fail_count', data.long_power_fail_count).catch(this.error)); }
-      }
-      else if ((data.long_power_fail_count == undefined) && (this.hasCapability('long_power_fail_count'))) {
-        promises.push(this.removeCapability('long_power_fail_count').catch(this.error));
-      }
-
-      // voltage_sag_l1_count - Net L1 dip
-      if (data.voltage_sag_l1_count !== undefined) {
-        if (!this.hasCapability('voltage_sag_l1')) {
-          promises.push(this.addCapability('voltage_sag_l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('voltage_sag_l1') != data.voltage_sag_l1_count)
-        { promises.push(this.setCapabilityValue('voltage_sag_l1', data.voltage_sag_l1_count).catch(this.error)); }
-      }
-      else if ((data.voltage_sag_l1_count == undefined) && (this.hasCapability('voltage_sag_l1'))) {
-        promises.push(this.removeCapability('voltage_sag_l1').catch(this.error));
-      }
-
-      // voltage_sag_l2_count - Net L2 dip
-      if (data.voltage_sag_l2_count !== undefined) {
-        if (!this.hasCapability('voltage_sag_l2')) {
-          promises.push(this.addCapability('voltage_sag_l2').catch(this.error));
-        }
-        if (this.getCapabilityValue('voltage_sag_l2') != data.voltage_sag_l2_count)
-        { promises.push(this.setCapabilityValue('voltage_sag_l2', data.voltage_sag_l2_count).catch(this.error)); }
-      }
-      else if ((data.voltage_sag_l2_count == undefined) && (this.hasCapability('voltage_sag_l2'))) {
-        promises.push(this.removeCapability('voltage_sag_l2').catch(this.error));
-      }
-
-      // voltage_sag_l3_count - Net L3 dip
-      if (data.voltage_sag_l3_count !== undefined) {
-        if (!this.hasCapability('voltage_sag_l3')) {
-          promises.push(this.addCapability('voltage_sag_l3').catch(this.error));
-        }
-        if (this.getCapabilityValue('voltage_sag_l3') != data.voltage_sag_l3_count)
-        { promises.push(this.setCapabilityValue('voltage_sag_l3', data.voltage_sag_l3_count).catch(this.error)); }
-      }
-      else if ((data.voltage_sag_l3_count == undefined) && (this.hasCapability('voltage_sag_l3'))) {
-        promises.push(this.removeCapability('voltage_sag_l3').catch(this.error));
-      }
-
-      // voltage_swell_l1_count - Net L1 peak
-      if (data.voltage_swell_l1_count !== undefined) {
-        if (!this.hasCapability('voltage_swell_l1')) {
-          promises.push(this.addCapability('voltage_swell_l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('voltage_swell_l1') != data.voltage_swell_l1_count)
-        { promises.push(this.setCapabilityValue('voltage_swell_l1', data.voltage_swell_l1_count).catch(this.error)); }
-      }
-      else if ((data.voltage_swell_l1_count == undefined) && (this.hasCapability('voltage_swell_l1'))) {
-        promises.push(this.removeCapability('voltage_swell_l1').catch(this.error));
-      }
-
-      // voltage_swell_l2_count - Net L2 peak
-      if (data.voltage_swell_l2_count !== undefined) {
-        if (!this.hasCapability('voltage_swell_l2')) {
-          promises.push(this.addCapability('voltage_swell_l2').catch(this.error));
-        }
-        if (this.getCapabilityValue('voltage_swell_l2') != data.voltage_swell_l2_count)
-        { promises.push(this.setCapabilityValue('voltage_swell_l2', data.voltage_swell_l2_count).catch(this.error)); }
-      }
-      else if ((data.voltage_swell_l2_count == undefined) && (this.hasCapability('voltage_swell_l2'))) {
-        promises.push(this.removeCapability('voltage_swell_l2').catch(this.error));
-      }
-
-      // voltage_swell_l3_count - Net L3 peak
-      if (data.voltage_swell_l3_count !== undefined) {
-        if (!this.hasCapability('voltage_swell_l3')) {
-          promises.push(this.addCapability('voltage_swell_l3').catch(this.error));
-        }
-        if (this.getCapabilityValue('voltage_swell_l3') != data.voltage_swell_l3_count)
-        { promises.push(this.setCapabilityValue('voltage_swell_l3', data.voltage_swell_l3_count).catch(this.error)); }
-      }
-      else if ((data.voltage_swell_l3_count == undefined) && (this.hasCapability('voltage_swell_l3'))) {
-        promises.push(this.removeCapability('voltage_swell_l3').catch(this.error));
-      }
-
-      // Rewrite of L1/L2/L3 Voltage/Amp
-      if (data.power_l1_w !== undefined) {
-        if (!this.hasCapability('measure_power.l1')) {
-          promises.push(this.addCapability('measure_power.l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_power.l1') != data.power_l1_w)
-        { promises.push(this.setCapabilityValue('measure_power.l1', data.power_l1_w).catch(this.error)); }
-      }
-      else if ((data.power_l1_w == undefined) && (this.hasCapability('measure_power.l1'))) {
-        promises.push(this.removeCapability('measure_power.l1').catch(this.error));
-      }
-
-      if (data.power_l2_w !== undefined) {
-        if (!this.hasCapability('measure_power.l2')) {
-          promises.push(this.addCapability('measure_power.l2').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_power.l2') != data.power_l2_w)
-        { promises.push(this.setCapabilityValue('measure_power.l2', data.power_l2_w).catch(this.error)); }
-      }
-      else if ((data.power_l2_w == undefined) && (this.hasCapability('measure_power.l2'))) {
-        promises.push(this.removeCapability('measure_power.l2').catch(this.error));
-      }
-
-      if (data.power_l3_w !== undefined) {
-        if (!this.hasCapability('measure_power.l3')) {
-          promises.push(this.addCapability('measure_power.l3').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_power.l3') != data.power_l3_w)
-        { promises.push(this.setCapabilityValue('measure_power.l3', data.power_l3_w).catch(this.error)); }
-      }
-      else if ((data.power_l3_w == undefined) && (this.hasCapability('measure_power.l3'))) {
-        promises.push(this.removeCapability('measure_power.l3').catch(this.error));
-      }
-
-      if (data.voltage_l1_v !== undefined) {
-        if (!this.hasCapability('measure_voltage.l1')) {
-          promises.push(this.addCapability('measure_voltage.l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_voltage.l1') != data.voltage_l1_v)
-        { promises.push(this.setCapabilityValue('measure_voltage.l1', data.voltage_l1_v).catch(this.error)); }
-      }
-      else if ((data.voltage_l1_v == undefined) && (this.hasCapability('measure_voltage.l1'))) {
-        promises.push(this.removeCapability('measure_voltage.l1').catch(this.error));
-      }
-
-      if (data.voltage_l2_v !== undefined) {
-        if (!this.hasCapability('measure_voltage.l2')) {
-          promises.push(this.addCapability('measure_voltage.l2').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_voltage.l2') != data.voltage_l2_v)
-        { promises.push(this.setCapabilityValue('measure_voltage.l2', data.voltage_l2_v).catch(this.error)); }
-      }
-      else if ((data.voltage_l2_v == undefined) && (this.hasCapability('measure_voltage.l2'))) {
-        promises.push(this.removeCapability('measure_voltage.l2').catch(this.error));
-      }
-
-      if (data.voltage_l3_v !== undefined) {
-        if (!this.hasCapability('measure_voltage.l3')) {
-          promises.push(this.addCapability('measure_voltage.l3').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_voltage.l3') != data.voltage_l3_v)
-        { promises.push(this.setCapabilityValue('measure_voltage.l3', data.voltage_l3_v).catch(this.error)); }
-      }
-      else if ((data.voltage_l3_v == undefined) && (this.hasCapability('measure_voltage.l3'))) {
-        promises.push(this.removeCapability('measure_voltage.l3').catch(this.error));
-      }
-
-      if (data.current_l1_a !== undefined) {
-        if (!this.hasCapability('measure_current.l1')) {
-          promises.push(this.addCapability('measure_current.l1').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_current.l1') != data.current_l1_a)
-        { promises.push(this.setCapabilityValue('measure_current.l1', data.current_l1_a).catch(this.error)); }
-      }
-      else if ((data.current_l1_a == undefined) && (this.hasCapability('measure_current.l1'))) {
-        promises.push(this.removeCapability('measure_current.l1').catch(this.error));
-      }
-
-      if (data.current_l2_a !== undefined) {
-        if (!this.hasCapability('measure_current.l2')) {
-          promises.push(this.addCapability('measure_current.l2').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_current.l2') != data.current_l2_a)
-        { promises.push(this.setCapabilityValue('measure_current.l2', data.current_l2_a).catch(this.error)); }
-      }
-      else if ((data.current_l2_a == undefined) && (this.hasCapability('measure_current.l2'))) {
-        promises.push(this.removeCapability('measure_current.l2').catch(this.error));
-      }
-
-      if (data.current_l3_a !== undefined) {
-        if (!this.hasCapability('measure_current.l3')) {
-          promises.push(this.addCapability('measure_current.l3').catch(this.error));
-        }
-        if (this.getCapabilityValue('measure_current.l3') != data.current_l3_a)
-        { promises.push(this.setCapabilityValue('measure_current.l3', data.current_l3_a).catch(this.error)); }
-      }
-      else if ((data.current_l3_a == undefined) && (this.hasCapability('measure_current.l3'))) {
-        promises.push(this.removeCapability('measure_current.l3').catch(this.error));
-      }
-
-      // T3 meter request import and export
-      if (data.total_power_import_t3_kwh !== undefined) {
-        if (!this.hasCapability('meter_power.consumed.t3')) {
-          promises.push(this.addCapability('meter_power.consumed.t3').catch(this.error));
-        }
-        if (this.getCapabilityValue('meter_power.consumed.t3') != data.total_power_import_t3_kwh)
-        { promises.push(this.setCapabilityValue('meter_power.consumed.t3', data.total_power_import_t3_kwh).catch(this.error)); }
-      }
-      else if ((data.total_power_import_t3_kwh == undefined) && (this.hasCapability('meter_power.consumed.t3'))) {
-        promises.push(this.removeCapability('meter_power.consumed.t3').catch(this.error));
-      }
-
-      if (data.total_power_export_t3_kwh !== undefined) {
-        if (!this.hasCapability('meter_power.produced.t3')) {
-          promises.push(this.addCapability('meter_power.produced.t3').catch(this.error));
-        }
-        if (this.getCapabilityValue('meter_power.produced.t3') != data.total_power_export_t3_kwh)
-        { promises.push(this.setCapabilityValue('meter_power.produced.t3', data.total_power_export_t3_kwh).catch(this.error)); }
-      }
-      else if ((data.total_power_export_t3_kwh == undefined) && (this.hasCapability('meter_power.produced.t3'))) {
-        promises.push(this.removeCapability('meter_power.produced.t3').catch(this.error));
-      }
+      // Trigger flows
+      triggerFlowPromises.push(this._triggerFlowOnChange('tariff_changed', data.tariff).catch(this.error));
+      triggerFlowPromises.push(this._triggerFlowOnChange('import_changed', data.energy_import_kwh).catch(this.error));
+      triggerFlowPromises.push(this._triggerFlowOnChange('export_changed', data.energy_export_kwh).catch(this.error));
 
       // Accessing external data
       const externalData = data.external;
@@ -469,20 +236,19 @@ module.exports = class HomeWizardEnergyDeviceV2 extends Homey.Device {
         const waterValue = latestWaterData.value;
 
         if (!this.hasCapability('meter_water')) {
-          promises.push(this.addCapability('meter_water').catch(this.error));
+          setCapabilityPromises.push(this.addCapability('meter_water').catch(this.error));
         }
 
-        if (this.getCapabilityValue('meter_water') != waterValue)
-        { promises.push(this.setCapabilityValue('meter_water', waterValue).catch(this.error)); }
+        if (this.getCapabilityValue('meter_water') != waterValue) { setCapabilityPromises.push(this.setCapabilityValue('meter_water', waterValue).catch(this.error)); }
 
       } else if (this.hasCapability('meter_water')) {
-        promises.push(this.removeCapability('meter_water').catch(this.error));
+        setCapabilityPromises.push(this.removeCapability('meter_water').catch(this.error));
         console.log('Removed meter as there is no water meter in P1.');
       }
 
       // Execute all promises concurrently using Promise.all()
-      Promise.all(promises);
-
+      Promise.all(setCapabilityPromises);
+      Promise.all(triggerFlowPromises);
     })
       .then(() => {
         this.setAvailable().catch(this.error);

--- a/drivers/plugin_battery/device.js
+++ b/drivers/plugin_battery/device.js
@@ -8,13 +8,11 @@ const POLL_INTERVAL = 1000 * 10; // 10 seconds
 module.exports = class HomeWizardPluginBattery extends Homey.Device {
 
   async onInit() {
+    await this._updateCapabilities();
+    await this._registerCapabilityListeners();
+
     this.onPollInterval = setInterval(this.onPoll.bind(this), POLL_INTERVAL);
-
     this.token = this.getStoreValue('token');
-
-    this.registerCapabilityListener('identify', async (value) => {
-      await api.identify(this.url, this.token);
-    });
   }
 
   onDeleted() {
@@ -43,6 +41,60 @@ module.exports = class HomeWizardPluginBattery extends Homey.Device {
     this.onPoll();
   }
 
+  async _updateCapabilities() {
+
+    if (!this.hasCapability('identify')) {
+      await this.addCapability('identify').catch(this.error);
+      console.log(`created capability identify for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('meter_power.import')) {
+      await this.addCapability('meter_power.import').catch(this.error);
+      console.log(`created capability meter_power.import for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('meter_power.export')) {
+      await this.addCapability('meter_power.export').catch(this.error);
+      console.log(`created capability meter_power.export for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('measure_power')) {
+      await this.addCapability('measure_power').catch(this.error);
+      console.log(`created capability measure_power for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('measure_voltage')) {
+      await this.addCapability('measure_voltage').catch(this.error);
+      console.log(`created capability measure_voltage for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('measure_current')) {
+      await this.addCapability('measure_current').catch(this.error);
+      console.log(`created capability measure_current for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('measure_battery')) {
+      await this.addCapability('measure_battery').catch(this.error);
+      console.log(`created capability measure_battery for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('battery_charging_state')) {
+      await this.addCapability('battery_charging_state').catch(this.error);
+      console.log(`created capability battery_charging_state for ${this.getName()}`);
+    }
+
+    if (!this.hasCapability('cycles')) {
+      await this.addCapability('cycles').catch(this.error);
+      console.log(`created capability cycles for ${this.getName()}`);
+    }
+  }
+
+  async _registerCapabilityListeners() {
+    this.registerCapabilityListener('identify', async (value) => {
+      await api.identify(this.url, this.token);
+    });
+  }
+
   onPoll() {
 
     // URL may be undefined if the device is not available
@@ -52,109 +104,35 @@ module.exports = class HomeWizardPluginBattery extends Homey.Device {
 
       const data = await api.getMeasurement(this.url, this.token);
 
-      // energy_import_kwh	Number	The energy usage meter reading in kWh.
-      // energy_export_kwh	Number	The energy feed-in meter reading in kWh.
-      // power_w	Number	The total active usage in watt.
-      // voltage_l1_v	Number	The active voltage in volt.
-      // current_a	Number	The active current in ampere.
-      // frequency_hz	Number	Line frequency in hertz.
-      // state_of_charge_pct	Number	The current state of charge in percent.
-      // cycles	Number	Number of battery cycles.
-
-      // Save export data check if capabilities are present first
-
-      // identify
-      if (!this.hasCapability('identify')) {
-        await this.addCapability('identify').catch(this.error);
-      }
-
       // energy_import_kwh
-      if (data.energy_import_kwh !== undefined) {
-        if (!this.hasCapability('meter_power.import')) {
-          await this.addCapability('meter_power.import').catch(this.error);
-        }
-        if (this.getCapabilityValue('meter_power.import') != data.energy_import_kwh) { await this.setCapabilityValue('meter_power.import', data.energy_import_kwh).catch(this.error); }
-      }
-      else if ((data.energy_import_kwh == undefined) && (this.hasCapability('meter_power.import'))) {
-        await this.removeCapability('meter_power.import').catch(this.error);
-      }
+      await this.setCapabilityValue('meter_power.import', data.energy_import_kwh).catch(this.error);
 
       // energy_export_kwh
-      if (data.energy_export_kwh !== undefined) {
-        if (!this.hasCapability('meter_power.export')) {
-          await this.addCapability('meter_power.export').catch(this.error);
-        }
-        if (this.getCapabilityValue('meter_power.export') != data.energy_export_kwh) { await this.setCapabilityValue('meter_power.export', data.energy_export_kwh).catch(this.error); }
-      }
-      else if ((data.energy_export_kwh == undefined) && (this.hasCapability('meter_power.export'))) {
-        await this.removeCapability('meter_power.export').catch(this.error);
-      }
+      await this.setCapabilityValue('meter_power.export', data.energy_export_kwh).catch(this.error);
 
       // power_w
-      if (data.power_w !== undefined) {
-        if (!this.hasCapability('measure_power')) {
-          await this.addCapability('measure_power').catch(this.error);
-        }
-        if (this.getCapabilityValue('measure_power') != data.power_w) { await this.setCapabilityValue('measure_power', data.power_w).catch(this.error); }
-      }
-      else if ((data.power_w == undefined) && (this.hasCapability('measure_power'))) {
-        await this.removeCapability('measure_power').catch(this.error);
-      }
+      await this.setCapabilityValue('measure_power', data.power_w).catch(this.error);
 
       // voltage_l1_v
-      if (data.voltage_l1_v !== undefined) {
-        if (!this.hasCapability('measure_voltage')) {
-          await this.addCapability('measure_voltage').catch(this.error);
-        }
-        if (this.getCapabilityValue('measure_voltage') != data.voltage_l1_v) { await this.setCapabilityValue('measure_voltage', data.voltage_l1_v).catch(this.error); }
-      }
-      else if ((data.voltage_l1_v == undefined) && (this.hasCapability('measure_voltage'))) {
-        await this.removeCapability('measure_voltage').catch(this.error);
-      }
+      await this.setCapabilityValue('measure_voltage', data.voltage_v).catch(this.error);
 
       // current_a  Amp's
-      if (data.current_a !== undefined) {
-        if (!this.hasCapability('measure_current')) {
-          await this.addCapability('measure_current').catch(this.error);
-        }
-        if (this.getCapabilityValue('measure_current') != data.current_a) { await this.setCapabilityValue('measure_current', data.current_a).catch(this.error); }
-      }
-      else if ((data.current_a == undefined) && (this.hasCapability('measure_current'))) {
-        await this.removeCapability('measure_current').catch(this.error);
-      }
+      await this.setCapabilityValue('measure_current', data.current_a).catch(this.error);
 
-      // measure_battery
-      if (data.state_of_charge_pct !== undefined) {
-        if (!this.hasCapability('measure_battery')) {
-          await this.addCapability('measure_battery').catch(this.error);
-        }
-        if (this.getCapabilityValue('measure_battery') != data.state_of_charge_pct) { await this.setCapabilityValue('measure_battery', data.state_of_charge_pct).catch(this.error); }
-      }
-      else if ((data.state_of_charge_pct == undefined) && (this.hasCapability('measure_battery'))) {
-        await this.removeCapability('measure_battery').catch(this.error);
-      }
+      // measure_battery in percent
+      await this.setCapabilityValue('measure_battery', data.state_of_charge_pct).catch(this.error);
 
-      // Round Trip Efficiency energy_export_kwh / energy_import_kwh * 100
-
-      // battery_charging_state - not support by HW battery
-      if (data.power_w > 0) {
+      // battery_charging_state
+      if (data.power_w > 10) { // Add some tolerance for idle consumption
         await this.setCapabilityValue('battery_charging_state', 'charging').catch(this.error);
-
       } else if (data.power_w < 0) {
         await this.setCapabilityValue('battery_charging_state', 'discharging').catch(this.error);
-
       } else {
         await this.setCapabilityValue('battery_charging_state', 'idle').catch(this.error);
       }
 
-      // battery Cycles - custom metric needs to be added
-
-      if (data.cycles !== undefined) {
-        if (!this.hasCapability('cycles')) {
-          await this.addCapability('cycles').catch(this.error);
-        }
-        if (this.getCapabilityValue('cycles') != data.cycles) { await this.setCapabilityValue('cycles', data.cycles).catch(this.error); }
-      }
+      // battery Cycles - custom metric needs to be added{
+      await this.setCapabilityValue('cycles', data.cycles).catch(this.error);
 
     })
       .then(() => {


### PR DESCRIPTION
This was a bit of a rabbit hole so this ended up being a big change... But I am _pretty_ confident that there are no breaking changes, we even got some extra sensors.

- For battery, moved creation of capabilities to init to reduce _a tiny bit_ of the load during polling
- For P1 Meter I started to do the same, but I forgot that every smart meter provides different data. So I've ended up cleaning up the implementation. I think it performs the same (or worse), but it feels a bit more maintain friendly.
  - I left the 'external' alone for now
  - I don't think we need that flow trigger thingy, but I implemented because I don't know if/how it is used
  - Implemented all tariffs, and found that `data.total_power_import_t3_kwh` was still the 'old' JSON name. Fixed that.
  
  
"Works on my machine", so _please_ _**please**_ let users know things can break.